### PR TITLE
8359218: RISC-V: Only enable CRC32 intrinsic when AvoidUnalignedAccess == false

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -203,15 +203,15 @@ void VM_Version::common_initialize() {
     }
   }
 
-  // Misc Intrinsics could depend on RVV
+  // Misc Intrinsics that could depend on RVV.
 
-  if (UseZba || UseRVV) {
+  if (!AvoidUnalignedAccesses && (UseZba || UseRVV)) {
     if (FLAG_IS_DEFAULT(UseCRC32Intrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32Intrinsics, true);
     }
   } else {
     if (!FLAG_IS_DEFAULT(UseCRC32Intrinsics)) {
-      warning("CRC32 intrinsic requires Zba or RVV instructions (not available on this CPU)");
+      warning("CRC32 intrinsic are not available on this CPU.");
     }
     FLAG_SET_DEFAULT(UseCRC32Intrinsics, false);
   }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [65e63b6a](https://github.com/openjdk/jdk/commit/65e63b6ab4241fc9d683e2ffa5bfe6e1a30059b6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Anjian Wen on 12 Jun 2025 and was reviewed by Fei Yang and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359218](https://bugs.openjdk.org/browse/JDK-8359218) needs maintainer approval

### Issue
 * [JDK-8359218](https://bugs.openjdk.org/browse/JDK-8359218): RISC-V: Only enable CRC32 intrinsic when AvoidUnalignedAccess == false (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/4.diff">https://git.openjdk.org/jdk25u/pull/4.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/4#issuecomment-2975294261)
</details>
