### PR TITLE
8359270: C2: alignment check should consider base offset when emitting arraycopy runtime call

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -1575,9 +1575,14 @@ bool LibraryCallKit::inline_string_toBytesU() {
     Node* src_start = array_element_address(value, offset, T_CHAR);
     Node* dst_start = basic_plus_adr(newcopy, arrayOopDesc::base_offset_in_bytes(T_BYTE));
 
-    // Check if src array address is aligned to HeapWordSize (dst is always aligned)
-    const TypeInt* toffset = gvn().type(offset)->is_int();
-    bool aligned = toffset->is_con() && ((toffset->get_con() * type2aelembytes(T_CHAR)) % HeapWordSize == 0);
+    // Check if dst array address is aligned to HeapWordSize
+    bool aligned = (arrayOopDesc::base_offset_in_bytes(T_BYTE) % HeapWordSize == 0);
+    // If true, then check if src array address is aligned to HeapWordSize
+    if (aligned) {
+      const TypeInt* toffset = gvn().type(offset)->is_int();
+      aligned = toffset->is_con() && ((arrayOopDesc::base_offset_in_bytes(T_CHAR) +
+                                       toffset->get_con() * type2aelembytes(T_CHAR)) % HeapWordSize == 0);
+    }
 
     // Figure out which arraycopy runtime method to call (disjoint, uninitialized).
     const char* copyfunc_name = "arraycopy";
@@ -1658,8 +1663,8 @@ bool LibraryCallKit::inline_string_getCharsU() {
     // Check if array addresses are aligned to HeapWordSize
     const TypeInt* tsrc = gvn().type(src_begin)->is_int();
     const TypeInt* tdst = gvn().type(dst_begin)->is_int();
-    bool aligned = tsrc->is_con() && ((tsrc->get_con() * type2aelembytes(T_BYTE)) % HeapWordSize == 0) &&
-                   tdst->is_con() && ((tdst->get_con() * type2aelembytes(T_CHAR)) % HeapWordSize == 0);
+    bool aligned = tsrc->is_con() && ((arrayOopDesc::base_offset_in_bytes(T_BYTE) + tsrc->get_con() * type2aelembytes(T_BYTE)) % HeapWordSize == 0) &&
+                   tdst->is_con() && ((arrayOopDesc::base_offset_in_bytes(T_CHAR) + tdst->get_con() * type2aelembytes(T_CHAR)) % HeapWordSize == 0);
 
     // Figure out which arraycopy runtime method to call (disjoint, uninitialized).
     const char* copyfunc_name = "arraycopy";

--- a/test/hotspot/jtreg/compiler/c2/irTests/stringopts/TestArrayCopySelect.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/stringopts/TestArrayCopySelect.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, Institute of Software, Chinese Academy of Sciences.
+ * All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests.stringopts;
+
+import compiler.lib.ir_framework.*;
+
+/**
+ * @test
+ * @bug 8359270
+ * @requires vm.debug == true & vm.compiler2.enabled
+ * @requires os.arch=="amd64" | os.arch=="x86_64" | os.arch=="riscv64" | os.arch=="aarch64"
+ * @summary C2: alignment check should consider base offset when emitting arraycopy runtime call.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.stringopts.TestArrayCopySelect
+ */
+
+public class TestArrayCopySelect {
+
+    public static final String input_strU = "\u0f21\u0f22\u0f23\u0f24\u0f25\u0f26\u0f27\u0f28";
+    public static final char[] input_arrU = new char[] {'\u0f21', '\u0f22', '\u0f23', '\u0f24',
+                                                        '\u0f25', '\u0f26', '\u0f27', '\u0f28'};
+
+    public static String output_strU;
+    public static char[] output_arrU;
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:-UseCompactObjectHeaders",
+                                   "-XX:-CompactStrings",
+                                   "-XX:CompileCommand=inline,java.lang.StringBuilder::toString",
+                                   "-XX:CompileCommand=inline,java.lang.StringUTF16::getChars",
+                                   "-XX:CompileCommand=inline,java.lang.StringUTF16::toBytes");
+
+        TestFramework.runWithFlags("-XX:+UseCompactObjectHeaders",
+                                   "-XX:-CompactStrings",
+                                   "-XX:CompileCommand=inline,java.lang.StringBuilder::toString",
+                                   "-XX:CompileCommand=inline,java.lang.StringUTF16::getChars",
+                                   "-XX:CompileCommand=inline,java.lang.StringUTF16::toBytes");
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(applyIf = {"UseCompactObjectHeaders", "false"},
+        counts = {IRNode.CALL_OF, "arrayof_jshort_disjoint_arraycopy", ">0"})
+    static void testSBToStringAligned() {
+        // Exercise the StringBuilder.toString API
+        StringBuilder sb = new StringBuilder(input_strU);
+        output_strU = sb.append(input_strU).toString();
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(applyIf = {"UseCompactObjectHeaders", "true"},
+        counts = {IRNode.CALL_OF, "arrayof_jshort_disjoint_arraycopy", "0"})
+    static void testSBToStringUnAligned() {
+        // Exercise the StringBuilder.toString API
+        StringBuilder sb = new StringBuilder(input_strU);
+        output_strU = sb.append(input_strU).toString();
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(applyIf = {"UseCompactObjectHeaders", "false"},
+        counts = {IRNode.CALL_OF, "arrayof_jshort_disjoint_arraycopy", ">0"})
+    static void testStrUGetCharsAligned() {
+        // Exercise the StringUTF16.getChars API
+        output_arrU = input_strU.toCharArray();
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(applyIf = {"UseCompactObjectHeaders", "true"},
+        counts = {IRNode.CALL_OF, "arrayof_jshort_disjoint_arraycopy", "0"})
+    static void testStrUGetCharsUnAligned() {
+        // Exercise the StringUTF16.getChars API
+        output_arrU = input_strU.toCharArray();
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(applyIf = {"UseCompactObjectHeaders", "false"},
+        counts = {IRNode.CALL_OF, "arrayof_jshort_disjoint_arraycopy", ">0"})
+    static void testStrUtoBytesAligned() {
+        // Exercise the StringUTF16.toBytes API
+        output_strU = String.valueOf(input_arrU);
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(applyIf = {"UseCompactObjectHeaders", "true"},
+        counts = {IRNode.CALL_OF, "arrayof_jshort_disjoint_arraycopy", "0"})
+    static void testStrUtoBytesUnAligned() {
+        // Exercise the StringUTF16.toBytes API
+        output_strU = String.valueOf(input_arrU);
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6b439391](https://github.com/openjdk/jdk/commit/6b4393917ae689818d67fcaf9cc61ca16ea6d426) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 23 Jun 2025 and was reviewed by Tobias Hartmann and Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359270](https://bugs.openjdk.org/browse/JDK-8359270) needs maintainer approval

### Issue
 * [JDK-8359270](https://bugs.openjdk.org/browse/JDK-8359270): C2: alignment check should consider base offset when emitting arraycopy runtime call (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/6.diff">https://git.openjdk.org/jdk25u/pull/6.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/6#issuecomment-3006798549)
</details>
