### PR TITLE
8358577: Test serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java failed: unexpexcted monitor object

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,9 +154,9 @@ class contmon01Task implements Runnable {
         System.out.println("check #2 done");
 
         System.out.println("notifying main thread");
+        System.out.println("thread is going to loop while <flag> is true ...");
         contmon01.startingBarrier = false;
 
-        System.out.println("thread is going to loop while <flag> is true ...");
         int i = 0;
         int n = 1000;
         while (flag) {


### PR DESCRIPTION
Backports the test improvement added by JDK-8358577 in JDK tip (26). Applies cleanly. Affected test
passes. Risk is low: the change is test code only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8358577](https://bugs.openjdk.org/browse/JDK-8358577) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358577](https://bugs.openjdk.org/browse/JDK-8358577): Test serviceability/jvmti/thread/GetCurrentContendedMonitor/contmon01/contmon01.java failed: unexpexcted monitor object (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/7.diff">https://git.openjdk.org/jdk25u/pull/7.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/7#issuecomment-3009220102)
</details>
