### PR TITLE
8360533: ContainerRuntimeVersionTestUtils fromVersionString fails with some docker versions

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/ContainerRuntimeVersionTestUtils.java
@@ -79,12 +79,21 @@ public class ContainerRuntimeVersionTestUtils implements Comparable<ContainerRun
         try {
             // Example 'docker version 20.10.0 or podman version 4.9.4-rhel'
             String versNums = version.split("\\s+", 3)[2];
+            // On some docker implementations e.g. RHEL8 ppc64le we have the following version output:
+            //    Docker version v25.0.3, build 4debf41
+            // Trim potentially leading 'v' and trailing ','
+            if (versNums.startsWith("v")) {
+                versNums = versNums.substring(1);
+            }
+            int cidx = versNums.indexOf(',');
+            versNums = (cidx != -1) ? versNums.substring(0, cidx) : versNums;
+
             String[] numbers = versNums.split("-")[0].split("\\.", 3);
             return new ContainerRuntimeVersionTestUtils(Integer.parseInt(numbers[0]),
                     Integer.parseInt(numbers[1]),
                     Integer.parseInt(numbers[2]));
         } catch (Exception e) {
-            throw new RuntimeException("Failed to parse container runtime version: " + version);
+            throw new RuntimeException("Failed to parse container runtime version: " + version, e);
         }
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8360533](https://bugs.openjdk.org/browse/JDK-8360533) needs maintainer approval

### Issue
 * [JDK-8360533](https://bugs.openjdk.org/browse/JDK-8360533): ContainerRuntimeVersionTestUtils fromVersionString fails with some docker versions (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/10.diff">https://git.openjdk.org/jdk25u/pull/10.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/10#issuecomment-3018234330)
</details>
