### PR TITLE
8359889: java/awt/MenuItem/SetLabelTest.java inadvertently triggers clicks on items pinned to the taskbar

### DIFF
--- a/test/jdk/java/awt/MenuItem/SetLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/SetLabelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,7 @@ public class SetLabelTest {
         });
         frame.setMenuBar(mb);
         frame.setSize(300, 200);
-        frame.setLocation(500,500);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
This is the backport of a test stabilisation fix done by @manukumarvs and approved by @aivanov-jdk.

Issue:
In Windows, java/awt/MenuItem/SetLabelTest.java inadvertently triggers clicks on items pinned to the taskbar. This may open some other UI item and may interfere further testing on that machine.

Fix:
Move the test UI to the centre of the screen by calling frame.setLocationRelativeTo(null).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359889](https://bugs.openjdk.org/browse/JDK-8359889) needs maintainer approval

### Issue
 * [JDK-8359889](https://bugs.openjdk.org/browse/JDK-8359889): java/awt/MenuItem/SetLabelTest.java inadvertently triggers clicks on items pinned to the taskbar (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/12.diff">https://git.openjdk.org/jdk25u/pull/12.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/12#issuecomment-3035217252)
</details>
