### PR TITLE
Backport 74822ce12acaf9816aa49b75ab5817ced3710776

### DIFF
--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -206,6 +206,8 @@ void CodeBlob::purge() {
   if (_mutable_data != blob_end()) {
     os::free(_mutable_data);
     _mutable_data = blob_end(); // Valid not null address
+    _mutable_data_size = 0;
+    _relocation_size = 0;
   }
   if (_oop_maps != nullptr) {
     delete _oop_maps;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -2182,6 +2182,7 @@ void nmethod::purge(bool unregister_nmethod) {
   }
   CodeCache::unregister_old_nmethod(this);
 
+  JVMCI_ONLY( _metadata_size = 0; )
   CodeBlob::purge();
 }
 


### PR DESCRIPTION
This is the backport of the JVMCI metadata crash fix.

Issue:
When flushing nmethods via CodeBlob::purge(), the JVMCI metadata was freed (mutable_data) but its size fields remained non-zero. As a result, invoking heap analytics via jcmd Compiler.CodeHeap_Analytics still walks the purged metadata and calls jvmci_name() on arbitrary memory, leading to intermittent crashes

Fix:
Extend CodeBlob::purge() to zero out the _mutable_data_size, _relocation_size, and _metadata_size fields so that after a purge jvmci_data_size() returns 0 and CompileBroker::print_heapinfo() skips any JVMCI metadata