### PR TITLE
8361829: [TESTBUG] RISC-V: compiler/vectorization/runner/BasicIntOpTest.java fails with RVV but not Zvbb

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -141,7 +141,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx2", "true", "zvbb", "true"},
         counts = {IRNode.POPCOUNT_VI, ">0"})
     public int[] vectorPopCount() {
         int[] res = new int[SIZE];


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2e7e272d](https://github.com/openjdk/jdk/commit/2e7e272d7b5273bae8684095bcda2a9c8bd21dc8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 11 Jul 2025 and was reviewed by Fei Yang and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361829](https://bugs.openjdk.org/browse/JDK-8361829) needs maintainer approval

### Issue
 * [JDK-8361829](https://bugs.openjdk.org/browse/JDK-8361829): [TESTBUG] RISC-V: compiler/vectorization/runner/BasicIntOpTest.java fails with RVV but not Zvbb (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/17.diff">https://git.openjdk.org/jdk25u/pull/17.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/17#issuecomment-3060142742)
</details>
