### PR TITLE
8362582: GHA: Increase bundle retention time to deal with infra overload better

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -65,4 +65,4 @@ runs:
       with:
         name: bundles-jtreg-${{ steps.version.outputs.value }}
         path: jtreg/installed
-        retention-days: 1
+        retention-days: 5

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -91,5 +91,5 @@ runs:
       with:
         name: bundles-${{ inputs.platform }}${{ inputs.debug-suffix }}${{ inputs.static-suffix }}${{ inputs.bundle-suffix }}
         path: bundles
-        retention-days: 1
+        retention-days: 5
       if: steps.bundles.outputs.bundles-found == 'true'


### PR DESCRIPTION
Improves GHA reliability.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362582](https://bugs.openjdk.org/browse/JDK-8362582) needs maintainer approval

### Issue
 * [JDK-8362582](https://bugs.openjdk.org/browse/JDK-8362582): GHA: Increase bundle retention time to deal with infra overload better (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/21.diff">https://git.openjdk.org/jdk25u/pull/21.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/21#issuecomment-3096505542)
</details>
