### PR TITLE
8357694: RISC-V: Several IR verification tests fail when vlen=128

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
@@ -296,7 +296,11 @@ public class TestIfMinMax {
 
     @Test
     @IR(applyIf = { "SuperWordReductions", "true" },
-        applyIfCPUFeatureOr = { "avx512", "true", "rvv", "true" },
+        applyIfCPUFeature = { "avx512", "true" },
+        counts = { IRNode.MAX_REDUCTION_V, "> 0" })
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
+        applyIfCPUFeature = { "rvv", "true" },
         counts = { IRNode.MAX_REDUCTION_V, "> 0" })
     @Arguments(setup = "setupLongArrays")
     public Object[] testMaxLongReduction(long[] a, long[] b) {
@@ -331,7 +335,11 @@ public class TestIfMinMax {
 
     @Test
     @IR(applyIf = { "SuperWordReductions", "true" },
-        applyIfCPUFeatureOr = { "avx512", "true", "rvv", "true" },
+        applyIfCPUFeature = { "avx512", "true" },
+        counts = { IRNode.MIN_REDUCTION_V, "> 0" })
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfAnd = { "SuperWordReductions", "true", "MaxVectorSize", ">=32" },
+        applyIfCPUFeature = { "rvv", "true" },
         counts = { IRNode.MIN_REDUCTION_V, "> 0" })
     @Arguments(setup = "setupLongArrays")
     public Object[] testMinLongReduction(long[] a, long[] b) {

--- a/test/hotspot/jtreg/compiler/loopopts/superword/RedTest_long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/RedTest_long.java
@@ -140,7 +140,7 @@ public class RedTest_long {
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long sumReductionImplement(
             long[] a,
@@ -162,7 +162,7 @@ public class RedTest_long {
         counts = {IRNode.OR_REDUCTION_V, ">= 1", IRNode.OR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.OR_REDUCTION_V, ">= 1", IRNode.OR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long orReductionImplement(
             long[] a,
@@ -184,7 +184,7 @@ public class RedTest_long {
         counts = {IRNode.AND_REDUCTION_V, ">= 1", IRNode.AND_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.AND_REDUCTION_V, ">= 1", IRNode.AND_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long andReductionImplement(
             long[] a,
@@ -206,7 +206,7 @@ public class RedTest_long {
         counts = {IRNode.XOR_REDUCTION_V, ">= 1", IRNode.XOR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.XOR_REDUCTION_V, ">= 1", IRNode.XOR_REDUCTION_V, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long xorReductionImplement(
             long[] a,
@@ -228,7 +228,7 @@ public class RedTest_long {
         counts = {IRNode.MUL_REDUCTION_VL, ">= 1", IRNode.MUL_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.MUL_REDUCTION_VL, ">= 1", IRNode.MUL_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long mulReductionImplement(
             long[] a,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/SumRed_Long.java
@@ -98,7 +98,7 @@ public class SumRed_Long {
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeature = {"rvv", "true"},
-        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8"},
+        applyIfAnd = {"SuperWordReductions", "true", "LoopMaxUnroll", ">= 8", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VL, ">= 1", IRNode.ADD_REDUCTION_VL, "<= 2"}) // one for main-loop, one for vector-post-loop
     public static long sumReductionImplement(
             long[] a,

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -81,9 +81,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnGlobalAccumulator(long[] array) {
         acc = 0;
@@ -94,9 +98,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnPartiallyUnrolledLoop(long[] array) {
         int sum = 0;
@@ -108,9 +116,13 @@ public class TestGeneralizedReductions {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
         applyIf = {"SuperWordReductions", "true"},
         applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1"})
     private static long testReductionOnLargePartiallyUnrolledLoop(long[] array) {
         int sum = 0;

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestUnorderedReductionPartialVectorization.java
@@ -66,7 +66,19 @@ public class TestUnorderedReductionPartialVectorization {
                   IRNode.OR_REDUCTION_V,                                                 "> 0",},
         applyIfOr = {"AlignVector", "false", "UseCompactObjectHeaders", "false"},
         applyIfPlatform = {"64-bit", "true"},
-        applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"})
+        applyIfCPUFeature = {"avx2", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.OR_REDUCTION_V,                                                 "> 0",},
+        applyIfAnd = {"AlignVector", "false", "MaxVectorSize", ">=32"},
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I,   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.VECTOR_CAST_I2L, IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                  IRNode.OR_REDUCTION_V,                                                 "> 0",},
+        applyIfAnd = {"UseCompactObjectHeaders", "false", "MaxVectorSize", ">=32"},
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"})
     static long test1(int[] data, long sum) {
         for (int i = 0; i < data.length; i+=2) {
             // Mixing int and long ops means we only end up allowing half of the int

--- a/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/LoopReductionOpTest.java
@@ -177,7 +177,11 @@ public class LoopReductionOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.STORE_VECTOR, ">0"})
-    @IR(applyIfCPUFeatureOr = {"avx2", "true", "rvv", "true"},
+    @IR(applyIfCPUFeature = {"avx2", "true"},
+        counts = {IRNode.ADD_REDUCTION_V, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {"rvv", "true"},
+        applyIf = {"MaxVectorSize", ">=32" },
         counts = {IRNode.ADD_REDUCTION_V, ">0"})
     public long reductionWithNonReductionDifferentSizes() {
         long res = 0L;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [15b5b54a](https://github.com/openjdk/jdk/commit/15b5b54ac707ba0d4e473fd6eb02c38a8efe705c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 21 Jul 2025 and was reviewed by Manuel Hässig, Fei Yang and Hamlin Li.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357694](https://bugs.openjdk.org/browse/JDK-8357694) needs maintainer approval

### Issue
 * [JDK-8357694](https://bugs.openjdk.org/browse/JDK-8357694): RISC-V: Several IR verification tests fail when vlen=128 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/22.diff">https://git.openjdk.org/jdk25u/pull/22.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/22#issuecomment-3097241660)
</details>
