### PR TITLE
8358697: TextLayout/MyanmarTextTest.java passes if no Myanmar font is found

### DIFF
--- a/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
+++ b/test/jdk/java/awt/font/TextLayout/MyanmarTextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,15 @@
  * @key headful
  * @summary Verifies that Myanmar script is rendered correctly:
  *          two characters combined into one glyph
+ * @library /test/lib
+ * @build jtreg.SkippedException
  * @run main MyanmarTextTest
  */
 
 import java.awt.Font;
 import java.awt.GraphicsEnvironment;
 import java.util.Arrays;
+import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JFrame;
@@ -45,12 +48,16 @@ import javax.swing.plaf.TextUI;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Position;
 
+import jtreg.SkippedException;
+
 public class MyanmarTextTest {
     private static final String TEXT = "\u1000\u103C";
 
-    private static final String FONT_WINDOWS = "Myanmar Text";
-    private static final String FONT_LINUX = "Padauk";
-    private static final String FONT_MACOS = "Myanmar MN";
+    private static final List<String> FONT_CANDIDATES =
+            List.of("Myanmar MN",
+                    "Padauk",
+                    "Myanmar Text",
+                    "Noto Sans Myanmar");
 
     private static final String FONT_NAME = selectFontName();
 
@@ -61,12 +68,8 @@ public class MyanmarTextTest {
 
     public static void main(String[] args) throws Exception {
         if (FONT_NAME == null) {
-            System.err.println("Unsupported OS: exiting");
-            return;
-        }
-        if (!fontExists()) {
-            System.err.println("Required font is not installed: " + FONT_NAME);
-            return;
+            throw new SkippedException("No suitable font found out of the list: "
+                    + String.join(", ", FONT_CANDIDATES));
         }
 
         try {
@@ -130,22 +133,12 @@ public class MyanmarTextTest {
     }
 
     private static String selectFontName() {
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.contains("windows")) {
-            return FONT_WINDOWS;
-        } else if (osName.contains("linux")) {
-            return FONT_LINUX;
-        } else if (osName.contains("mac")) {
-            return FONT_MACOS;
-        } else {
-            return null;
-        }
+        return Arrays.stream(GraphicsEnvironment
+                             .getLocalGraphicsEnvironment()
+                             .getAvailableFontFamilyNames())
+                     .filter(FONT_CANDIDATES::contains)
+                     .findFirst()
+                     .orElse(null);
     }
 
-    private static boolean fontExists() {
-        String[] fontFamilyNames = GraphicsEnvironment
-                                   .getLocalGraphicsEnvironment()
-                                   .getAvailableFontFamilyNames();
-        return Arrays.asList(fontFamilyNames).contains(FONT_NAME);
-    }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bcad87ea](https://github.com/openjdk/jdk/commit/bcad87eacbd7fbfd3254479b7e061bab34e64aec) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Manukumar V S on 24 Jun 2025 and was reviewed by Alexey Ivanov.

Testing: Tested using mach5 in all available platforms and got full Pass.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358697](https://bugs.openjdk.org/browse/JDK-8358697) needs maintainer approval

### Issue
 * [JDK-8358697](https://bugs.openjdk.org/browse/JDK-8358697): TextLayout/MyanmarTextTest.java passes if no Myanmar font is found (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/24.diff">https://git.openjdk.org/jdk25u/pull/24.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/24#issuecomment-3097857341)
</details>
