### PR TITLE
8362834: Several runtime/Thread tests should mark as /native

### DIFF
--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionOnMonitorEnter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8283044
  * @summary Stress delivery of asynchronous exceptions while target is at monitorenter
  * @library /test/hotspot/jtreg/testlibrary
- * @run main/othervm AsyncExceptionOnMonitorEnter 0
+ * @run main/othervm/native AsyncExceptionOnMonitorEnter 0
  * @run main/othervm/native -agentlib:AsyncExceptionOnMonitorEnter AsyncExceptionOnMonitorEnter 1
  */
 

--- a/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
+++ b/test/hotspot/jtreg/runtime/Thread/AsyncExceptionTest.java
@@ -27,13 +27,14 @@
  * @requires vm.compiler1.enabled | vm.compiler2.enabled
  * @summary Stress delivery of asynchronous exceptions.
  * @library /test/hotspot/jtreg/testlibrary
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:+StressCompiledExceptionHandlers
+ * @run main/othervm/native
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressCompiledExceptionHandlers
  *                   -Xcomp -XX:TieredStopAtLevel=3
  *                   -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
  *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
  *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2
  *                   AsyncExceptionTest
- * @run main/othervm -Xcomp
+ * @run main/othervm/native -Xcomp
  *                   -XX:CompileCommand=dontinline,AsyncExceptionTest::internalRun2
  *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun1
  *                   -XX:CompileCommand=compileonly,AsyncExceptionTest::internalRun2

--- a/test/hotspot/jtreg/runtime/Thread/TestBreakSignalThreadDump.java
+++ b/test/hotspot/jtreg/runtime/Thread/TestBreakSignalThreadDump.java
@@ -28,7 +28,7 @@
  * @summary Check that Ctrl-\ or Ctrl-Break (on Windows) causes HotSpot VM to print a full thread dump.
  * @library /vmTestbase
  *          /test/lib
- * @run driver TestBreakSignalThreadDump
+ * @run main/native TestBreakSignalThreadDump
  */
 
 /*
@@ -42,7 +42,7 @@
  * @requires !vm.asan
  * @library /vmTestbase
  *          /test/lib
- * @run driver TestBreakSignalThreadDump load_libjsig
+ * @run main/native TestBreakSignalThreadDump load_libjsig
  */
 
 import java.nio.file.Files;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [699b8112](https://github.com/openjdk/jdk/commit/699b8112f8da7ceef2aa2a3ddb326aee88b29f8c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 22 Jul 2025 and was reviewed by David Holmes.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362834](https://bugs.openjdk.org/browse/JDK-8362834) needs maintainer approval

### Issue
 * [JDK-8362834](https://bugs.openjdk.org/browse/JDK-8362834): Several runtime/Thread tests should mark as /native (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/25.diff">https://git.openjdk.org/jdk25u/pull/25.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/25#issuecomment-3100296189)
</details>
