### PR TITLE
8361504: RISC-V: Make C1 clone intrinsic platform guard more specific

### DIFF
--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -238,7 +238,7 @@ bool Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_counterTime:
 #endif
   case vmIntrinsics::_getObjectSize:
-#if defined(X86) || defined(AARCH64) || defined(S390) || defined(RISCV) || defined(PPC64)
+#if defined(X86) || defined(AARCH64) || defined(S390) || defined(RISCV64) || defined(PPC64)
   case vmIntrinsics::_clone:
 #endif
     break;

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -350,7 +350,7 @@ LIR_OpArrayCopy::LIR_OpArrayCopy(LIR_Opr src, LIR_Opr src_pos, LIR_Opr dst, LIR_
   , _tmp(tmp)
   , _expected_type(expected_type)
   , _flags(flags) {
-#if defined(X86) || defined(AARCH64) || defined(S390) || defined(RISCV) || defined(PPC64)
+#if defined(X86) || defined(AARCH64) || defined(S390) || defined(RISCV64) || defined(PPC64)
   if (expected_type != nullptr && flags == 0) {
     _stub = nullptr;
   } else {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [54e37629](https://github.com/openjdk/jdk/commit/54e37629f63eae7800415fa22684e6b3df3648ec) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Feilong Jiang on 9 Jul 2025 and was reviewed by Fei Yang and Gui Cao.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8361504](https://bugs.openjdk.org/browse/JDK-8361504) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361504](https://bugs.openjdk.org/browse/JDK-8361504): RISC-V: Make C1 clone intrinsic platform guard more specific (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/29.diff">https://git.openjdk.org/jdk25u/pull/29.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/29#issuecomment-3109190244)
</details>
