### PR TITLE
8363898: RISC-V: TestRangeCheckHoistingScaledIV.java fails after JDK-8355293 when running without RVV

### DIFF
--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeCheckHoistingScaledIV.java
@@ -28,7 +28,8 @@
  * @summary Test range check hoisting for some scaled iv at array index
  * @library /test/lib /
  * @requires vm.flagless
- * @requires vm.debug & vm.compiler2.enabled & (os.simpleArch == "x64" | os.arch == "aarch64" | os.arch == "riscv64")
+ * @requires vm.debug & vm.compiler2.enabled
+ * @requires os.simpleArch == "x64" | os.arch == "aarch64" | (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @modules jdk.incubator.vector
  * @run main/othervm compiler.rangechecks.TestRangeCheckHoistingScaledIV
  */


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b746701e](https://github.com/openjdk/jdk/commit/b746701e5769a7a5a1e7900ddfdd285706ac5fe1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 24 Jul 2025 and was reviewed by Fei Yang, Hamlin Li and SendaoYan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363898](https://bugs.openjdk.org/browse/JDK-8363898) needs maintainer approval

### Issue
 * [JDK-8363898](https://bugs.openjdk.org/browse/JDK-8363898): RISC-V: TestRangeCheckHoistingScaledIV.java fails after JDK-8355293 when running without RVV (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/30.diff">https://git.openjdk.org/jdk25u/pull/30.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/30#issuecomment-3111674410)
</details>
