### PR TITLE
8361888: [GCC static analyzer] ProcessImpl_md.c Java_java_lang_ProcessImpl_forkAndExec error: use of uninitialized value '*(ChildStuff *)p.mode

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -732,7 +732,7 @@ Java_java_lang_ProcessImpl_forkAndExec(JNIEnv *env,
         (fds[2] == -1 && pipe(err) < 0) ||
         (pipe(childenv) < 0) ||
         (pipe(fail) < 0)) {
-        throwInternalIOException(env, errno, "Bad file descriptor", c->mode);
+        throwInternalIOException(env, errno, "Bad file descriptor", mode);
         goto Catch;
     }
     c->fds[0] = fds[0];


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361888](https://bugs.openjdk.org/browse/JDK-8361888) needs maintainer approval

### Issue
 * [JDK-8361888](https://bugs.openjdk.org/browse/JDK-8361888): [GCC static analyzer] ProcessImpl_md.c Java_java_lang_ProcessImpl_forkAndExec error: use of uninitialized value '*(ChildStuff *)p.mode (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/34.diff">https://git.openjdk.org/jdk25u/pull/34.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/34#issuecomment-3112666569)
</details>
