### PR TITLE
8363895: Minimal build fails with slowdebug builds after JDK-8354887

### DIFF
--- a/src/hotspot/share/code/aotCodeCache.hpp
+++ b/src/hotspot/share/code/aotCodeCache.hpp
@@ -362,8 +362,8 @@ public:
   static void init2() NOT_CDS_RETURN;
   static void close() NOT_CDS_RETURN;
   static bool is_on() CDS_ONLY({ return _cache != nullptr && !_cache->closing(); }) NOT_CDS_RETURN_(false);
-  static bool is_on_for_use()  { return is_on() && _cache->for_use(); }
-  static bool is_on_for_dump() { return is_on() && _cache->for_dump(); }
+  static bool is_on_for_use()  CDS_ONLY({ return is_on() && _cache->for_use(); }) NOT_CDS_RETURN_(false);
+  static bool is_on_for_dump() CDS_ONLY({ return is_on() && _cache->for_dump(); }) NOT_CDS_RETURN_(false);
 
   static bool is_dumping_adapter() NOT_CDS_RETURN_(false);
   static bool is_using_adapter() NOT_CDS_RETURN_(false);


### PR DESCRIPTION
As [suggested](https://bugs.openjdk.org/browse/JDK-8363895), I would like to backport this patch. The patch has a context conflict, but the content itself is clean. This patch had already been [integrated into the Leyden premain branch](https://github.com/openjdk/jdk/pull/26436#issuecomment-3109531143) before it was merged into the jdk master.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8363895](https://bugs.openjdk.org/browse/JDK-8363895) needs maintainer approval

### Issue
 * [JDK-8363895](https://bugs.openjdk.org/browse/JDK-8363895): Minimal build fails with slowdebug builds after JDK-8354887 (**Bug** - P4 - Approved)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/37.diff">https://git.openjdk.org/jdk25u/pull/37.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/37#issuecomment-3113107774)
</details>
