### PR TITLE
8362838: RISC-V: Incorrect matching rule leading to improper oop instruction encoding

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2271,10 +2271,6 @@ encode %{
     __ mv(dst_reg, 1);
   %}
 
-  enc_class riscv_enc_mov_byte_map_base(iRegP dst) %{
-    __ load_byte_map_base($dst$$Register);
-  %}
-
   enc_class riscv_enc_mov_n(iRegN dst, immN src) %{
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
@@ -2818,21 +2814,6 @@ operand immP0()
 operand immP_1()
 %{
   predicate(n->get_ptr() == 1);
-  match(ConP);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Card Table Byte Map Base
-operand immByteMapBase()
-%{
-  // Get base of card map
-  predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
-            SHENANDOAHGC_ONLY(!BarrierSet::barrier_set()->is_a(BarrierSet::ShenandoahBarrierSet) &&)
-            (CardTable::CardValue*)n->get_ptr() ==
-             ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);
 
   op_cost(0);
@@ -4795,18 +4776,6 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   format %{ "mv  $dst, $con\t# load ptr constant one, #@loadConP1" %}
 
   ins_encode(riscv_enc_mov_p1(dst));
-
-  ins_pipe(ialu_imm);
-%}
-
-// Load Byte Map Base Constant
-instruct loadByteMapBase(iRegPNoSp dst, immByteMapBase con)
-%{
-  match(Set dst con);
-  ins_cost(ALU_COST);
-  format %{ "mv  $dst, $con\t# Byte Map Base, #@loadByteMapBase" %}
-
-  ins_encode(riscv_enc_mov_byte_map_base(dst));
 
   ins_pipe(ialu_imm);
 %}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0ba2942c](https://github.com/openjdk/jdk/commit/0ba2942c6e7aadc3d091c40f6bd8d9f7502f5f76) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Feilong Jiang on 24 Jul 2025 and was reviewed by Fei Yang and Yadong Wang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362838](https://bugs.openjdk.org/browse/JDK-8362838) needs maintainer approval

### Issue
 * [JDK-8362838](https://bugs.openjdk.org/browse/JDK-8362838): RISC-V: Incorrect matching rule leading to improper oop instruction encoding (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/38.diff">https://git.openjdk.org/jdk25u/pull/38.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/38#issuecomment-3113596660)
</details>
