### PR TITLE
Backport e6ac956a7ac613b916c0dbfda7e57856c1b8a83c

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -772,7 +772,7 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
   ciArrayKlass* expected_type = nullptr;
   arraycopy_helper(x, &flags, &expected_type);
   if (x->check_flag(Instruction::OmitChecksFlag)) {
-    flags = 0;
+    flags = (flags & LIR_OpArrayCopy::get_initial_copy_flags());
   }
 
   __ arraycopy(src.result(), src_pos.result(), dst.result(), dst_pos.result(), length.result(), tmp,

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -351,7 +351,8 @@ LIR_OpArrayCopy::LIR_OpArrayCopy(LIR_Opr src, LIR_Opr src_pos, LIR_Opr dst, LIR_
   , _expected_type(expected_type)
   , _flags(flags) {
 #if defined(X86) || defined(AARCH64) || defined(S390) || defined(RISCV64) || defined(PPC64)
-  if (expected_type != nullptr && flags == 0) {
+  if (expected_type != nullptr &&
+      ((flags & ~LIR_OpArrayCopy::get_initial_copy_flags()) == 0)) {
     _stub = nullptr;
   } else {
     _stub = new ArrayCopyStub(this);

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1282,6 +1282,8 @@ public:
   int flags() const                              { return _flags; }
   ciArrayKlass* expected_type() const            { return _expected_type; }
   ArrayCopyStub* stub() const                    { return _stub; }
+  static int get_initial_copy_flags()            { return LIR_OpArrayCopy::unaligned |
+                                                          LIR_OpArrayCopy::overlapping; }
 
   virtual void emit_code(LIR_Assembler* masm);
   virtual LIR_OpArrayCopy* as_OpArrayCopy() { return this; }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e6ac956a](https://github.com/openjdk/jdk/commit/e6ac956a7ac613b916c0dbfda7e57856c1b8a83c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Feilong Jiang on 23 Jul 2025 and was reviewed by Fei Yang, Galder Zamarreño and Dean Long.

Thanks!