### PR TITLE
8362855: Test java/net/ipv6tests/TcpTest.java should report SkippedException when there no ia4addr  or ia6addr

### DIFF
--- a/test/jdk/java/net/ipv6tests/TcpTest.java
+++ b/test/jdk/java/net/ipv6tests/TcpTest.java
@@ -31,12 +31,15 @@
  * @library /test/lib
  * @build jdk.test.lib.NetworkConfiguration
  *        jdk.test.lib.Platform
+ *        jtreg.SkippedException
  * @run main TcpTest -d
  */
 
 import java.net.*;
 import java.io.*;
 import java.util.concurrent.TimeUnit;
+
+import jtreg.SkippedException;
 
 public class TcpTest extends Tests {
     static ServerSocket server, server1, server2;
@@ -62,12 +65,10 @@ public class TcpTest extends Tests {
     public static void main (String[] args) throws Exception {
         checkDebug(args);
         if (ia4addr == null) {
-            System.out.println ("No IPV4 addresses: exiting test");
-            return;
+            throw new SkippedException("No IPV4 addresses: exiting test");
         }
         if (ia6addr == null) {
-            System.out.println ("No IPV6 addresses: exiting test");
-            return;
+            throw new SkippedException("No IPV6 addresses: exiting test");
         }
         dprintln ("Local Addresses");
         dprintln (ia4addr.toString());


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8fcbb110](https://github.com/openjdk/jdk/commit/8fcbb110e9941af5fe162c6affff36e0bf652bda) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 27 Jul 2025 and was reviewed by Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362855](https://bugs.openjdk.org/browse/JDK-8362855) needs maintainer approval

### Issue
 * [JDK-8362855](https://bugs.openjdk.org/browse/JDK-8362855): Test java/net/ipv6tests/TcpTest.java should report SkippedException when there no ia4addr  or ia6addr (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/41.diff">https://git.openjdk.org/jdk25u/pull/41.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/41#issuecomment-3123718850)
</details>
