### PR TITLE
Backport 3b0da29879990e4ed6d22c8aed0659f3b40c37a3

### DIFF
--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, 2024, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -56,6 +56,7 @@
 import jdk.test.lib.os.linux.HugePageConfiguration;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -123,6 +124,9 @@ public class TestHugePageDecisionsAtVMStartup {
             out.shouldContain(warningNoTHP);
         } else if (useLP && !useTHP &&
                  configuration.supportsExplicitHugePages() && haveUsableExplicitHugePages) {
+            if (configuration.getExplicitAvailableHugePageNumber() == 0) {
+                throw new SkippedException("No usable explicit hugepages configured on the system, skipping test");
+            }
             out.shouldContain("[info][pagesize] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3b0da298](https://github.com/openjdk/jdk/commit/3b0da29879990e4ed6d22c8aed0659f3b40c37a3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 28 Jul 2025 and was reviewed by Thomas Stuefe and David Holmes.

Thanks!