### PR TITLE
8362169: Pointer passed to upcall may get wrong scope

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -297,7 +297,7 @@ public class BindingSpecializer {
         if (callingSequence.allocationSize() != 0) {
             cb.loadConstant(callingSequence.allocationSize())
               .invokestatic(CD_SharedUtils, "newBoundedArena", MTD_NEW_BOUNDED_ARENA);
-        } else if (callingSequence.forUpcall() && needsSession()) {
+        } else if (callingSequence.forUpcall() && anyArgNeedsScope()) {
             cb.invokestatic(CD_SharedUtils, "newEmptyArena", MTD_NEW_EMPTY_ARENA);
         } else {
             cb.getstatic(CD_SharedUtils, "DUMMY_ARENA", CD_Arena);
@@ -437,7 +437,7 @@ public class BindingSpecializer {
         cb.exceptionCatchAll(tryStart, tryEnd, catchStart);
     }
 
-    private boolean needsSession() {
+    private boolean anyArgNeedsScope() {
         return callingSequence.argumentBindings()
                 .filter(BoxAddress.class::isInstance)
                 .map(BoxAddress.class::cast)
@@ -590,7 +590,7 @@ public class BindingSpecializer {
         popType(long.class);
         cb.loadConstant(boxAddress.size())
           .loadConstant(boxAddress.align());
-        if (needsSession()) {
+        if (boxAddress.needsScope()) {
             emitLoadInternalSession();
             cb.invokestatic(CD_Utils, "longToAddress", MTD_LONG_TO_ADDRESS_SCOPE);
         } else {

--- a/test/jdk/java/foreign/libTestUpcallStructScope.c
+++ b/test/jdk/java/foreign/libTestUpcallStructScope.c
@@ -28,3 +28,7 @@ struct S_PDI { void* p0; double p1; int p2; };
 EXPORT void do_upcall(void (*cb)(struct S_PDI), struct S_PDI a0) {
     cb(a0);
 }
+
+EXPORT void do_upcall_ptr(void (*cb)(struct S_PDI, void*), struct S_PDI a0, void* ptr) {
+    cb(a0, ptr);
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9dc62825](https://github.com/openjdk/jdk/commit/9dc62825b5e7300542d22df0b87b79116f3562d3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jorn Vernee on 18 Jul 2025 and was reviewed by Maurizio Cimadamore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362169](https://bugs.openjdk.org/browse/JDK-8362169) needs maintainer approval

### Issue
 * [JDK-8362169](https://bugs.openjdk.org/browse/JDK-8362169): Pointer passed to upcall may get wrong scope (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/46.diff">https://git.openjdk.org/jdk25u/pull/46.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/46#issuecomment-3128137477)
</details>
