### PR TITLE
8359428: Test 'javax/swing/JTabbedPane/bug4499556.java' failed because after selecting one of L&F items, the test case automatically failed when clicking on L&F Menu button again

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/bug4499556.java
+++ b/test/jdk/javax/swing/JTabbedPane/bug4499556.java
@@ -89,9 +89,10 @@ public class bug4499556 {
     }
 
     static volatile JTabbedPane pane;
+    static volatile JFrame frame;
 
     static JFrame createUI() {
-        JFrame frame = new JFrame("bug4499556");
+        frame = new JFrame("bug4499556");
         pane = getTabbedPane();
         frame.add(pane);
         frame.add(getRightPanel(), BorderLayout.EAST);
@@ -262,7 +263,7 @@ public class bug4499556 {
             e.printStackTrace();
             return false;
         }
-        SwingUtilities.updateComponentTreeUI(pane);
+        SwingUtilities.updateComponentTreeUI(frame);
         return true;
     }
 


### PR DESCRIPTION
**PR Changes**
It is seen that this test (which was opensourced in [JDK-8353304](https://bugs.openjdk.org/browse/JDK-8353304)) when run with NimbusLookAndFeel, after selecting one of L&F items, the test case automatically failed when clicking on L&F Menu button again.
It is because while switching to another L&F say platform(WindowsL&F) from Metal/Nimbus LookAndFeel, if testcase was originally run in Nimbus L&F, SynthMenuItemLayoutHelper() calls MenuItemLayoutHelper.reset where style.getFont(context) return null font so when it calls getFontMetrics(font) it calls font.hashCode which fails with

Execution failed: `main' threw exception: java.lang.NullPointerException: Cannot invoke "java.awt.Font.hashCode()" because "font" is null

This is happening because the test calls SwingUtilities.updateComponentTreeUI on tabbedpane.
So, when L&F is changed inside the test via "L&F Menu" option 1st time say Metal to Platform, it changes the L&F of the tabbed pane to Windows L&F, but not for the "L&F Menu" font itself which is still in Nimbus L&F, but style context is reset so when next time "L&F Menu" is clicked to change the L&F, SynthMenuItemLayoutHelper gets null font from invalid context and then it crashes.
Fix is to ensure the updateComponentTreeUI should be for entire frame which consists of "L&F Menu" and the tabs so L&F is changed consistently for all nodes.

**Testing**

 [JTREG Testing] (1 manual test )

runner starting test: javax/swing/JTabbedPane/bug4499556.java

runner finished test: javax/swing/JTabbedPane/bug4499556.java

Passed. Execution successful

Test results: passed: 1

**Conflicts**
[MR clean check] (A Clean Backport) -Yes

[Are higher backports completed(25u,21u,17u,11u,8u etc) ?]
Applicable to 25u via this MR and the others are being worked upon.

 [Does it contain multiple changesets ?] - No

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359428](https://bugs.openjdk.org/browse/JDK-8359428) needs maintainer approval

### Issue
 * [JDK-8359428](https://bugs.openjdk.org/browse/JDK-8359428): Test 'javax/swing/JTabbedPane/bug4499556.java' failed because after selecting one of L&amp;F items, the test case automatically failed when clicking on L&amp;F Menu button again (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/50.diff">https://git.openjdk.org/jdk25u/pull/50.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/50#issuecomment-3131370134)
</details>
