### PR TITLE
Backport ee0bcc55269e92e999862ae5c63ffad7a600f6cc

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
@@ -27,7 +27,7 @@
  * @requires vm.continuations
  * @modules jdk.management
  * @library /test/lib
- * @run junit/othervm --enable-native-access=ALL-UNNAMED UnmountedVThreadNativeMethodAtTop
+ * @run junit/othervm/native --enable-native-access=ALL-UNNAMED UnmountedVThreadNativeMethodAtTop
  */
 
 import java.lang.management.ManagementFactory;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ee0bcc55](https://github.com/openjdk/jdk/commit/ee0bcc55269e92e999862ae5c63ffad7a600f6cc) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 19 Jul 2025 and was reviewed by Serguei Spitsyn and Chris Plummer.

Thanks!