### PR TITLE
8361449: RISC-V: Code cleanup for native call

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -60,13 +60,13 @@ class NativeFarCall: public NativeInstruction {
   address next_instruction_address() const  { return addr_at(return_address_offset); }
   address return_address() const            { return addr_at(return_address_offset); }
   address destination() const;
-  address reloc_destination(address orig_address);
+  address reloc_destination();
 
   void set_destination(address dest);
   void verify();
   void print();
 
-  bool set_destination_mt_safe(address dest, bool assert_lock = true);
+  bool set_destination_mt_safe(address dest);
   bool reloc_set_destination(address dest);
 
  private:
@@ -88,7 +88,7 @@ address NativeFarCall::destination() const {
   address destination = MacroAssembler::target_addr_for_insn(addr);
 
   CodeBlob* cb = CodeCache::find_blob(addr);
-  assert(cb && cb->is_nmethod(), "sanity");
+  assert(cb != nullptr && cb->is_nmethod(), "nmethod expected");
   nmethod *nm = (nmethod *)cb;
   assert(nm != nullptr, "Sanity");
   assert(nm->stub_contains(destination), "Sanity");
@@ -96,20 +96,22 @@ address NativeFarCall::destination() const {
   return stub_address_destination_at(destination);
 }
 
-address NativeFarCall::reloc_destination(address orig_address) {
+address NativeFarCall::reloc_destination() {
   address call_addr = instruction_address();
+  assert(NativeFarCall::is_at(call_addr), "unexpected code at call site");
 
   CodeBlob *code = CodeCache::find_blob(call_addr);
   assert(code != nullptr, "Could not find the containing code blob");
 
   address stub_addr = nullptr;
-  if (code != nullptr && code->is_nmethod()) {
-    stub_addr = trampoline_stub_Relocation::get_trampoline_for(call_addr, (nmethod*)code);
+  if (code->is_nmethod()) {
+    stub_addr = trampoline_stub_Relocation::get_trampoline_for(call_addr, code->as_nmethod());
   }
 
   if (stub_addr != nullptr) {
     stub_addr = MacroAssembler::target_addr_for_insn(call_addr);
   }
+
   return stub_addr;
 }
 
@@ -128,18 +130,13 @@ void NativeFarCall::print() {
   tty->print_cr(PTR_FORMAT ": auipc,ld,jalr x1, offset/reg, ", p2i(addr_at(0)));
 }
 
-bool NativeFarCall::set_destination_mt_safe(address dest, bool assert_lock) {
+bool NativeFarCall::set_destination_mt_safe(address dest) {
   assert(NativeFarCall::is_at(addr_at(0)), "unexpected code at call site");
-  assert(!assert_lock ||
-         (CodeCache_lock->is_locked() || SafepointSynchronize::is_at_safepoint()) ||
+  assert((CodeCache_lock->is_locked() || SafepointSynchronize::is_at_safepoint()) ||
          CompiledICLocker::is_safe(addr_at(0)),
          "concurrent code patching");
 
-  address call_addr = addr_at(0);
-  assert(NativeFarCall::is_at(call_addr), "unexpected code at call site");
-
   address stub_addr = stub_address();
-
   if (stub_addr != nullptr) {
     set_stub_address_destination_at(stub_addr, dest);
     return true;
@@ -156,10 +153,9 @@ bool NativeFarCall::reloc_set_destination(address dest) {
   assert(code != nullptr, "Could not find the containing code blob");
 
   address stub_addr = nullptr;
-  if (code != nullptr && code->is_nmethod()) {
-    stub_addr = trampoline_stub_Relocation::get_trampoline_for(call_addr, (nmethod*)code);
+  if (code->is_nmethod()) {
+    stub_addr = trampoline_stub_Relocation::get_trampoline_for(call_addr, code->as_nmethod());
   }
-
   if (stub_addr != nullptr) {
     MacroAssembler::pd_patch_instruction_size(call_addr, stub_addr);
   }
@@ -209,7 +205,7 @@ bool NativeFarCall::is_at(address addr) {
       (MacroAssembler::extract_rd(addr + instr_size)       == x6) &&
       (MacroAssembler::extract_rs1(addr + instr_size)      == x6) &&
       (MacroAssembler::extract_rs1(addr + 2 * instr_size)  == x6) &&
-      (MacroAssembler::extract_rd(addr + 2 * instr_size)  == x1)) {
+      (MacroAssembler::extract_rd(addr + 2 * instr_size)   == x1)) {
     return true;
   }
   return false;
@@ -238,8 +234,8 @@ address NativeCall::destination() const {
   return NativeFarCall::at(addr_at(0))->destination();
 }
 
-address NativeCall::reloc_destination(address orig_address) {
-  return NativeFarCall::at(addr_at(0))->reloc_destination(orig_address);
+address NativeCall::reloc_destination() {
+  return NativeFarCall::at(addr_at(0))->reloc_destination();
 }
 
 void NativeCall::set_destination(address dest) {
@@ -254,8 +250,8 @@ void NativeCall::print() {
   NativeFarCall::at(addr_at(0))->print();;
 }
 
-bool NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
-  return NativeFarCall::at(addr_at(0))->set_destination_mt_safe(dest, assert_lock);
+bool NativeCall::set_destination_mt_safe(address dest) {
+  return NativeFarCall::at(addr_at(0))->set_destination_mt_safe(dest);
 }
 
 bool NativeCall::reloc_set_destination(address dest) {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -135,14 +135,14 @@ class NativeCall: private NativeInstruction {
   address next_instruction_address() const;
   address return_address() const;
   address destination() const;
-  address reloc_destination(address orig_address);
+  address reloc_destination();
 
   void verify_alignment() {} // do nothing on riscv
   void verify();
   void print();
 
   void set_destination(address dest);
-  bool set_destination_mt_safe(address dest, bool assert_lock = true);
+  bool set_destination_mt_safe(address dest);
   bool reloc_set_destination(address dest);
 
   static bool is_at(address addr);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [5edd5465](https://github.com/openjdk/jdk/commit/5edd546585d66f52c2e894ed212ee67945fe0785) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 14 Jul 2025 and was reviewed by Fei Yang and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361449](https://bugs.openjdk.org/browse/JDK-8361449) needs maintainer approval

### Issue
 * [JDK-8361449](https://bugs.openjdk.org/browse/JDK-8361449): RISC-V: Code cleanup for native call (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/57.diff">https://git.openjdk.org/jdk25u/pull/57.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/57#issuecomment-3143827564)
</details>
