### PR TITLE
8361255: CTW: Tolerate more NCDFE problems

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -28,7 +28,9 @@ import jdk.internal.misc.Unsafe;
 import jdk.internal.reflect.ConstantPool;
 import jdk.test.whitebox.WhiteBox;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.Executor;
@@ -79,26 +81,53 @@ public class Compiler {
             preloadClasses(aClass.getName(), id, constantPool);
         }
 
-        // Make sure the class is initialized.
-        UNSAFE.ensureClassInitialized(aClass);
+        // Attempt to initialize the class. If initialization is not possible
+        // due to NCDFE, accept this, and try compile anyway.
+        try {
+            UNSAFE.ensureClassInitialized(aClass);
+        } catch (NoClassDefFoundError e) {
+            CompileTheWorld.OUT.printf("[%d]\t%s\tNOTE unable to init class : %s%n",
+                id, aClass.getName(), e);
+        }
         compileClinit(aClass, id);
+
+        // Getting constructor/methods with unresolvable signatures would fail with NCDFE.
+        // Try to get as much as possible, and compile everything else.
+        // TODO: Would be good to have a Whitebox method that returns the subset of resolvable
+        // constructors/methods without throwing NCDFE. This would extend the testing scope.
+        Constructor[] constructors = new Constructor[0];
+        Method[] methods = new Method[0];
+
+        try {
+            constructors = aClass.getDeclaredConstructors();
+        } catch (NoClassDefFoundError e) {
+            CompileTheWorld.OUT.printf("[%d]\t%s\tNOTE unable to get constructors : %s%n",
+                id, aClass.getName(), e);
+        }
+
+        try {
+            methods = aClass.getDeclaredMethods();
+        } catch (NoClassDefFoundError e) {
+            CompileTheWorld.OUT.printf("[%d]\t%s\tNOTE unable to get methods : %s%n",
+                id, aClass.getName(), e);
+        }
 
         // Populate profile for all methods to expand the scope of
         // compiler optimizations. Do this before compilations start.
-        for (Executable e : aClass.getDeclaredConstructors()) {
+        for (Executable e : constructors) {
             WHITE_BOX.markMethodProfiled(e);
         }
-        for (Executable e : aClass.getDeclaredMethods()) {
+        for (Executable e : methods) {
             WHITE_BOX.markMethodProfiled(e);
         }
 
         // Now schedule the compilations.
         long methodCount = 0;
-        for (Executable e : aClass.getDeclaredConstructors()) {
+        for (Executable e : constructors) {
             ++methodCount;
             executor.execute(new CompileMethodCommand(id, e));
         }
-        for (Executable e : aClass.getDeclaredMethods()) {
+        for (Executable e : methods) {
             ++methodCount;
             executor.execute(new CompileMethodCommand(id, e));
         }
@@ -127,9 +156,12 @@ public class Compiler {
                 if (constantPool.getTagAt(i) == ConstantPool.Tag.CLASS) {
                     constantPool.getClassAt(i);
                 }
+            } catch (NoClassDefFoundError e) {
+                CompileTheWorld.OUT.printf("[%d]\t%s\tNOTE unable to preload : %s%n",
+                    id, className, e);
             } catch (Throwable t) {
-                CompileTheWorld.OUT.println(String.format("[%d]\t%s\tWARNING preloading failed : %s",
-                         id, className, t));
+                CompileTheWorld.OUT.printf("[%d]\t%s\tWARNING preloading failed : %s%n",
+                    id, className, t);
                 t.printStackTrace(CompileTheWorld.ERR);
             }
         }

--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/PathHandler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/PathHandler.java
@@ -245,9 +245,12 @@ public class PathHandler implements Closeable {
                 CompileTheWorld.OUT.println(String.format("[%d]\t%s", id, name));
                 aClass = entry.loader().loadClass(name);
                 Compiler.compileClass(aClass, id, executor);
+            } catch (NoClassDefFoundError e) {
+                CompileTheWorld.OUT.printf("[%d]\t%s\tNOTE unable to load/compile, skipped: %s%n",
+                    id, name, e);
             } catch (Throwable e) {
-                CompileTheWorld.OUT.println(String.format("[%d]\t%s\tWARNING skipped: %s",
-                        id, name, e));
+                CompileTheWorld.OUT.printf("[%d]\t%s\tWARNING skipped: %s%n",
+                    id, name, e);
                 e.printStackTrace(CompileTheWorld.ERR);
             }
         }


### PR DESCRIPTION
Improves testing coverage.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `application/ctw/modules`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8361255](https://bugs.openjdk.org/browse/JDK-8361255) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361255](https://bugs.openjdk.org/browse/JDK-8361255): CTW: Tolerate more NCDFE problems (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/58.diff">https://git.openjdk.org/jdk25u/pull/58.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/58#issuecomment-3144845326)
</details>
