### PR TITLE
8360255: runtime/jni/checked/TestLargeUTF8Length.java fails with -XX:-CompactStrings

### DIFF
--- a/test/hotspot/jtreg/runtime/jni/checked/TestLargeUTF8Length.java
+++ b/test/hotspot/jtreg/runtime/jni/checked/TestLargeUTF8Length.java
@@ -44,9 +44,14 @@ public class TestLargeUTF8Length {
     static native void checkUTF8Length(String s, long utf8Length);
 
     static void test() {
-        int length = Integer.MAX_VALUE/2 + 1;
-        char character = (char)0XD1; // N with tilde
-        long utf8Length = 2L * length;
+        // We want a string whose UTF-8 length is > Integer.MAX_VALUE, but
+        // whose "natural" length is < Integer.MAX_VALUE/2 so it can be
+        // created regardless of whether compact-strings are enabled or not.
+        // So we use a character that encodes as 3-bytes in UTF-8.
+        //   U+08A0 : e0 a2 a0 : ARABIC LETTER BEH WITH SMALL V BELOW
+        char character = '\u08A0';
+        int length = Integer.MAX_VALUE/2 - 1;
+        long utf8Length = 3L * length;
         char[] chrs = new char[length];
         Arrays.fill(chrs, character);
         String s = new String(chrs);


### PR DESCRIPTION
Fixes the test with `-XX:-CompactStrings`.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, affected test fails before the patch, passes with it

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8360255](https://bugs.openjdk.org/browse/JDK-8360255) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360255](https://bugs.openjdk.org/browse/JDK-8360255): runtime/jni/checked/TestLargeUTF8Length.java fails with -XX:-CompactStrings (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/65.diff">https://git.openjdk.org/jdk25u/pull/65.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/65#issuecomment-3155169115)
</details>
