### PR TITLE
8360647: [XWayland] [OL10] NumPad keys are not triggered

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -33,6 +33,7 @@
 
 #ifndef _AIX
 #include "screencast_pipewire.h"
+#include "java_awt_event_KeyEvent.h"
 
 struct pw_buffer *(*fp_pw_stream_dequeue_buffer)(struct pw_stream *stream);
 const char * (*fp_pw_stream_state_as_string)(enum pw_stream_state state);
@@ -1197,6 +1198,24 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
     return result ? RESULT_OK : pw.pwFd;
 }
 
+static int getNumpadKey(jint jkey) {
+    switch (jkey) {
+        case java_awt_event_KeyEvent_VK_NUMPAD0: return XK_KP_Insert;
+        case java_awt_event_KeyEvent_VK_NUMPAD1: return XK_KP_End;
+        case java_awt_event_KeyEvent_VK_NUMPAD2: return XK_KP_Down;
+        case java_awt_event_KeyEvent_VK_NUMPAD3: return XK_KP_Page_Down;
+        case java_awt_event_KeyEvent_VK_NUMPAD4: return XK_KP_Left;
+        case java_awt_event_KeyEvent_VK_NUMPAD5: return XK_KP_Begin;
+        case java_awt_event_KeyEvent_VK_NUMPAD6: return XK_KP_Right;
+        case java_awt_event_KeyEvent_VK_NUMPAD7: return XK_KP_Home;
+        case java_awt_event_KeyEvent_VK_NUMPAD8: return XK_KP_Up;
+        case java_awt_event_KeyEvent_VK_NUMPAD9: return XK_KP_Prior;
+        case java_awt_event_KeyEvent_VK_DECIMAL:
+        case java_awt_event_KeyEvent_VK_SEPARATOR: return XK_KP_Delete;
+        default: return 0;
+    }
+}
+
 /*
  * Class:     sun_awt_screencast_ScreencastHelper
  * Method:    remoteDesktopKeyImpl
@@ -1205,9 +1224,12 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopMou
 JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_remoteDesktopKeyImpl
         (JNIEnv *env, jclass cls, jboolean isPress, jint jkey, jstring jtoken) {
 
-    AWT_LOCK();
-    int key = awt_getX11KeySym(jkey);
-    AWT_UNLOCK();
+    int key = getNumpadKey(jkey);
+    if (!key) {
+        AWT_LOCK();
+        key = awt_getX11KeySym(jkey);
+        AWT_UNLOCK();
+    }
 
     if (key == NoSymbol || (*env)->ExceptionCheck(env)) {
         return RESULT_ERROR;


### PR DESCRIPTION
Hi all,

    This pull request contains a backport of commit [0029554d](https://github.com/openjdk/jdk/commit/0029554d20f22648994040a041c418d48a2a0eb4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

    The commit being backported was authored by Alexander Zvegintsev on 14 Jul 2025 and was reviewed by Harshitha Onkar and Sergey Bylokhov.

    Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8360647](https://bugs.openjdk.org/browse/JDK-8360647) needs maintainer approval

### Issue
 * [JDK-8360647](https://bugs.openjdk.org/browse/JDK-8360647): [XWayland] [OL10] NumPad keys are not triggered (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/68.diff">https://git.openjdk.org/jdk25u/pull/68.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/68#issuecomment-3157291673)
</details>
