### PR TITLE
8361180: Disable CompiledDirectCall verification with -VerifyInlineCaches

### DIFF
--- a/src/hotspot/share/code/compiledIC.hpp
+++ b/src/hotspot/share/code/compiledIC.hpp
@@ -192,13 +192,13 @@ private:
 
   static inline CompiledDirectCall* before(address return_addr) {
     CompiledDirectCall* st = new CompiledDirectCall(nativeCall_before(return_addr));
-    st->verify();
+    if (VerifyInlineCaches) st->verify();
     return st;
   }
 
   static inline CompiledDirectCall* at(address native_call) {
     CompiledDirectCall* st = new CompiledDirectCall(nativeCall_at(native_call));
-    st->verify();
+    if (VerifyInlineCaches) st->verify();
     return st;
   }
 


### PR DESCRIPTION
Further improves CTW performance.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, `applications/ctw/modules`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361180](https://bugs.openjdk.org/browse/JDK-8361180) needs maintainer approval

### Issue
 * [JDK-8361180](https://bugs.openjdk.org/browse/JDK-8361180): Disable CompiledDirectCall verification with -VerifyInlineCaches (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/71.diff">https://git.openjdk.org/jdk25u/pull/71.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/71#issuecomment-3158853718)
</details>
