### PR TITLE
Backport b4028c91d5615f43cbf209eeeb1014966de22a38

### DIFF
--- a/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/UnmountedVThreadNativeMethodAtTop.java
@@ -27,7 +27,9 @@
  * @requires vm.continuations
  * @modules jdk.management
  * @library /test/lib
- * @run junit/othervm/native --enable-native-access=ALL-UNNAMED UnmountedVThreadNativeMethodAtTop
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run junit/othervm/native -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI --enable-native-access=ALL-UNNAMED UnmountedVThreadNativeMethodAtTop
  */
 
 import java.lang.management.ManagementFactory;
@@ -45,8 +47,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import jdk.test.lib.hprof.model.Snapshot;
 import jdk.test.lib.hprof.model.ThreadObject;
 import jdk.test.lib.hprof.parser.Reader;
+import jdk.test.whitebox.WhiteBox;
 
 public class UnmountedVThreadNativeMethodAtTop {
+
+    static WhiteBox wb = WhiteBox.getWhiteBox();
 
     boolean done;
 
@@ -56,7 +61,7 @@ public class UnmountedVThreadNativeMethodAtTop {
      */
     @BeforeEach
     void doGC() {
-        System.gc();
+        wb.fullGC();
     }
 
     /**


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b4028c91](https://github.com/openjdk/jdk/commit/b4028c91d5615f43cbf209eeeb1014966de22a38) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Richard Reingruber on 28 Jul 2025 and was reviewed by Serguei Spitsyn and Christoph Langer.

Thanks!