### PR TITLE
8357822: C2: Multiple string optimization tests are no longer testing string concatenation optimizations

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7046096.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7046096.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,18 @@
  * @run main/othervm -Xbatch -XX:+IgnoreUnrecognizedVMOptions -XX:+OptimizeStringConcat
  *    compiler.c2.Test7046096
  */
+
+
+/*
+ * @test id=stringConcatInline
+ * @bug 7046096 8357822
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ *
+ * @compile -XDstringConcat=inline Test7046096.java
+ * @run main/othervm -Xbatch compiler.c2.Test7046096
+ */
+
 
 package compiler.c2;
 

--- a/test/hotspot/jtreg/compiler/c2/Test7179138_2.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7179138_2.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2012 Skip Balk.  All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,6 +32,18 @@
  *
  * @author Skip Balk
  */
+
+
+/*
+ * @test id=stringConcatInline
+ * @bug 7179138
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ *
+ * @compile -XDstringConcat=inline Test7179138_2.java
+ * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.c2.Test7179138_2
+ */
+
 
 package compiler.c2;
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Implicit01.java
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Implicit01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Implicit01.java
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Implicit01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_disabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_disabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Merge01.java
  * @run main/othervm -XX:-CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
  */
 

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_enabled/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/optimizations/stringconcat/implicit/Merge01/cs_enabled/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,20 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
+ */
+
+
+/*
+ * @test id=stringConcatInline
+ *
+ * @summary The same test with an updated compile directive that produces
+ *          StringBuilder-backed string concatenations.
+ * VM Testbase keywords: [jit, quick]
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @compile -XDstringConcat=inline ../../Merge01.java
  * @run main/othervm -XX:+CompactStrings vm.compiler.optimizations.stringconcat.implicit.Merge01
  */
 


### PR DESCRIPTION
Clean backport, adds several tests for string concatenation optimization in C2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357822](https://bugs.openjdk.org/browse/JDK-8357822) needs maintainer approval

### Issue
 * [JDK-8357822](https://bugs.openjdk.org/browse/JDK-8357822): C2: Multiple string optimization tests are no longer testing string concatenation optimizations (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/73.diff">https://git.openjdk.org/jdk25u/pull/73.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/73#issuecomment-3160813907)
</details>
