### PR TITLE
8360518: Docker tests do not work when asan is configured

### DIFF
--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Basic (sanity) test for JDK-under-test inside a docker image.
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
+++ b/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
@@ -28,6 +28,7 @@
  * @key cgroups
  * @summary Test for hsperfdata file name conflict when two containers share the same /tmp directory
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @build WaitForFlagFile
  * @run driver ShareTmpDir

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -27,6 +27,7 @@
  * @key cgroups
  * @summary Test JVM's CPU resource awareness when running inside docker container
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.platform

--- a/test/hotspot/jtreg/containers/docker/TestCPUSets.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUSets.java
@@ -27,6 +27,7 @@
  * @key cgroups
  * @summary Test JVM's awareness of cpu sets (cpus and mems)
  * @requires container.support
+ * @requires !vm.asan
  * @requires (os.arch != "s390x")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -28,6 +28,7 @@
  * @summary Test container info for cgroup v2
  * @key cgroups
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -30,6 +30,7 @@
  *          Also make sure that PIDs are based on value provided by container,
  *          not by the host system.
  * @requires (container.support & os.maxMemory >= 2g)
+ * @requires !vm.asan
  * @modules java.base/jdk.internal.platform
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
@@ -28,6 +28,7 @@
  *          the reported host ip and host name are correctly reported within
  *          the container.
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test JFR recording controlled via JMX across container boundary.
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -31,6 +31,7 @@
  *          namespace such as PID namespace, specific sub-directories, IPC and more.
  * @requires container.support
  * @requires vm.flagless
+ * @requires !vm.asan
  * @modules java.base/jdk.internal.misc
  *          java.management
  *          jdk.jartool/sun.tools.jar

--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -30,6 +30,7 @@
  * @key cgroups
  * @summary Test container limits updating as they get updated at runtime without restart
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox LimitUpdateChecker
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithCgroupV1.java
@@ -32,6 +32,7 @@ import jdk.internal.platform.Metrics;
  * @test
  * @key cgroups
  * @requires os.family == "linux"
+ * @requires !vm.asan
  * @modules java.base/jdk.internal.platform
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox PrintContainerInfo CheckOperatingSystemMXBean

--- a/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryWithSubgroups.java
@@ -36,6 +36,7 @@ import jtreg.SkippedException;
  * @test
  * @bug 8343191
  * @requires os.family == "linux"
+ * @requires !vm.asan
  * @modules java.base/jdk.internal.platform
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -26,6 +26,7 @@
  * @test
  * @summary Test miscellanous functionality related to JVM running in docker container
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -28,6 +28,7 @@
  * @key cgroups
  * @summary Test JVM's awareness of pids controller
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
@@ -28,6 +28,7 @@
  * @summary Verify that -XshowSettings:system works
  * @key cgroups
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @run main/timeout=360 TestDockerBasic
  */

--- a/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
@@ -35,6 +35,7 @@ import jdk.test.lib.containers.docker.DockerTestUtils;
  * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build MetricsCpuTester

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -33,6 +33,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build MetricsMemoryTester

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetricsSubgroup.java
@@ -40,6 +40,7 @@ import jtreg.SkippedException;
  * @key cgroups
  * @summary Cgroup v1 subsystem fails to set subsystem path
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build MetricsMemoryTester

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -27,6 +27,7 @@
  * @key cgroups
  * @bug 8242480
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @build GetFreeSwapSpaceSize
  * @run driver TestGetFreeSwapSpaceSize

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -30,6 +30,7 @@
  * @key cgroups
  * @summary Test container limits updating as they get updated at runtime without restart
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build LimitUpdateChecker

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -28,6 +28,7 @@
  * @summary Test JDK Metrics class when running inside a docker container with limited pids
  * @bug 8266490
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @build TestPidsLimit
  * @run driver TestPidsLimit

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -26,6 +26,7 @@
  * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @run main TestSystemMetrics

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -26,6 +26,7 @@
  * @test
  * @summary UseContainerSupport flag should reflect Metrics being available
  * @requires container.support
+ * @requires !vm.asan
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build CheckUseContainerSupport


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8360518](https://bugs.openjdk.org/browse/JDK-8360518) needs maintainer approval

### Issue
 * [JDK-8360518](https://bugs.openjdk.org/browse/JDK-8360518): Docker tests do not work when asan is configured (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/74/head:pull/74` \
`$ git checkout pull/74`

Update a local copy of the PR: \
`$ git checkout pull/74` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/74/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 74`

View PR using the GUI difftool: \
`$ git pr show -t 74`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/74.diff">https://git.openjdk.org/jdk25u/pull/74.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/74#issuecomment-3164029540)
</details>
