### PR TITLE
8364150: RISC-V: Leftover for JDK-8343430 removing old trampoline call

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -72,11 +72,9 @@ address NativeCall::reloc_destination() {
 
   address stub_addr = nullptr;
   if (code->is_nmethod()) {
+    // TODO: Need to revisit this when porting the AOT features.
     stub_addr = trampoline_stub_Relocation::get_trampoline_for(call_addr, code->as_nmethod());
-  }
-
-  if (stub_addr != nullptr) {
-    stub_addr = MacroAssembler::target_addr_for_insn(call_addr);
+    assert(stub_addr != nullptr, "Sanity");
   }
 
   return stub_addr;
@@ -113,12 +111,12 @@ bool NativeCall::reloc_set_destination(address dest) {
   CodeBlob *code = CodeCache::find_blob(call_addr);
   assert(code != nullptr, "Could not find the containing code blob");
 
-  address stub_addr = nullptr;
   if (code->is_nmethod()) {
-    stub_addr = trampoline_stub_Relocation::get_trampoline_for(call_addr, code->as_nmethod());
-  }
-  if (stub_addr != nullptr) {
-    MacroAssembler::pd_patch_instruction_size(call_addr, stub_addr);
+    // TODO: Need to revisit this when porting the AOT features.
+    assert(dest != nullptr, "Sanity");
+    assert(dest == trampoline_stub_Relocation::get_trampoline_for(call_addr,
+                                                          code->as_nmethod()), "Sanity");
+    MacroAssembler::pd_patch_instruction_size(call_addr, dest);
   }
 
   return true;

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -94,7 +94,6 @@ class NativeInstruction {
   static uint64_t get_data64_at(address src)                 { return Bytes::get_native_u8(src); }
 
  public:
-
   inline friend NativeInstruction* nativeInstruction_at(address addr);
 
   static bool maybe_cpool_ref(address instr) {
@@ -122,8 +121,8 @@ class NativeCall: private NativeInstruction {
     // to overload and hide it.
     instruction_size = 3 * NativeInstruction::instruction_size // auipc + ld + jalr
   };
- public:
 
+ public:
   static int byte_size() {
     return NativeCall::instruction_size; // auipc + ld + jalr
   }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [3488f53d](https://github.com/openjdk/jdk/commit/3488f53d2c3083bd886644684ec6885046ea7f8e) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 30 Jul 2025 and was reviewed by Hamlin Li and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8364150](https://bugs.openjdk.org/browse/JDK-8364150) needs maintainer approval

### Issue
 * [JDK-8364150](https://bugs.openjdk.org/browse/JDK-8364150): RISC-V: Leftover for JDK-8343430 removing old trampoline call (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/79.diff">https://git.openjdk.org/jdk25u/pull/79.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/79#issuecomment-3170057025)
</details>
