### PR TITLE
Backport e13b4c8de944ab14a1d12f6251e83f4fdd9e0198

### DIFF
--- a/src/java.base/share/classes/java/lang/ClassValue.java
+++ b/src/java.base/share/classes/java/lang/ClassValue.java
@@ -476,6 +476,9 @@ public abstract class ClassValue<T> {
                 if (updated != entry) {
                     put(classValue.identity, updated);
                 }
+                // Add to the cache, to enable the fast path, next time.
+                checkCacheLoad();
+                addToCache(classValue, updated);
             }
             return item;
         }


### PR DESCRIPTION
Backport of openjdk/jdk#26679 performance regression fix to 25 update releases. A release note for this regression has been written for 25 GA. The same patch has been backported to 25 GA branch and fixes the regression.