### PR TITLE
8362390: AIX make fails in awt_GraphicsEnv.c

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -1747,7 +1747,7 @@ Java_sun_awt_X11GraphicsDevice_initXrandrExtension
 // ---------------------------------------------------
 // display mode change via XRRSetCrtcConfig
 // ---------------------------------------------------
-
+#if !defined(NO_XRANDR)
 static jint refreshRateFromModeInfo(const XRRModeInfo *modeInfo) {
     if (!modeInfo->hTotal || !modeInfo->vTotal) {
         return 0;
@@ -2031,6 +2031,7 @@ static void xrrChangeDisplayMode(jint screen, jint width, jint height, jint refr
         }
         awt_XRRFreeScreenResources(res);
 }
+#endif
 
 // ---------------------------------------------------
 // display mode change via XRRSetCrtcConfig


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 18190519 from the openjdk/jdk repository.

The commit being backported was authored by Matthias Baesken on 17 Jul 2025 and was reviewed by Phil Race, Sergey Bylokhov and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8362390](https://bugs.openjdk.org/browse/JDK-8362390) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362390](https://bugs.openjdk.org/browse/JDK-8362390): AIX make fails in awt_GraphicsEnv.c (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/84.diff">https://git.openjdk.org/jdk25u/pull/84.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/84#issuecomment-3175226898)
</details>
