### PR TITLE
8365200: RISC-V: compiler/loopopts/superword/TestGeneralizedReductions.java fails with Zvbb and vlen=128

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestGeneralizedReductions.java
@@ -160,13 +160,13 @@ public class TestGeneralizedReductions {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"avx2", "true"},
-        applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "UsePopCountInstruction", "true"},
         applyIfPlatform = {"64-bit", "true"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})
     @IR(applyIfPlatform = {"riscv64", "true"},
         applyIfCPUFeatureOr = {"zvbb", "true"},
-        applyIfAnd = {"SuperWordReductions", "true","UsePopCountInstruction", "true"},
+        applyIfAnd = {"SuperWordReductions", "true", "UsePopCountInstruction", "true", "MaxVectorSize", ">=32"},
         counts = {IRNode.ADD_REDUCTION_VI, ">= 1",
                   IRNode.POPCOUNT_VL, ">= 1"})
     private static long testMapReductionOnGlobalAccumulator(long[] array) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6927fc39](https://github.com/openjdk/jdk/commit/6927fc3904eb239bd43ab7c581d479c00a6a4af2) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 12 Aug 2025 and was reviewed by Fei Yang and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365200](https://bugs.openjdk.org/browse/JDK-8365200) needs maintainer approval

### Issue
 * [JDK-8365200](https://bugs.openjdk.org/browse/JDK-8365200): RISC-V: compiler/loopopts/superword/TestGeneralizedReductions.java fails with Zvbb and vlen=128 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/85.diff">https://git.openjdk.org/jdk25u/pull/85.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/85#issuecomment-3177467815)
</details>
