### PR TITLE
Backport bdb1646a1e39bae0535efe3f593e7fc0545e4114

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -62,7 +62,8 @@ BUILD_JDK_JTREG_LIBRARIES_JDK_LIBS_libGetXSpace := java.base:libjava
 ifeq ($(call isTargetOs, windows), true)
   BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c \
       libExplicitAttach.c libImplicitAttach.c \
-      exelauncher.c
+      exelauncher.c \
+      libChangeSignalDisposition.c exePrintSignalDisposition.c
 
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX)
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exerevokeall := advapi32.lib

--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -416,6 +416,11 @@ childProcess(void *arg)
     if (fcntl(FAIL_FILENO, F_SETFD, FD_CLOEXEC) == -1)
         goto WhyCantJohnnyExec;
 
+    // Children should be started with default signal disposition for SIGPIPE
+    if (signal(SIGPIPE, SIG_DFL) == SIG_ERR) {
+        goto WhyCantJohnnyExec;
+    }
+
     JDK_execvpe(p->mode, p->argv[0], p->argv, p->envv);
 
  WhyCantJohnnyExec:

--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/TestChildSignalDisposition.java
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/TestChildSignalDisposition.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test id=posix_spawn
+ * @bug 8364611
+ * @summary Check that childs start with SIG_DFL as SIGPIPE disposition
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=posix_spawn -agentlib:ChangeSignalDisposition TestChildSignalDisposition
+ */
+
+/**
+ * @test id=fork
+ * @bug 8364611
+ * @summary Check that childs start with SIG_DFL as SIGPIPE disposition
+ * @requires os.family != "windows"
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=fork -agentlib:ChangeSignalDisposition TestChildSignalDisposition
+ */
+
+/**
+ * @test id=vfork
+ * @bug 8364611
+ * @summary Check that childs start with SIG_DFL as SIGPIPE disposition
+ * @requires os.family == "linux"
+ * @library /test/lib
+ * @run main/othervm/native -Djdk.lang.Process.launchMechanism=vfork -agentlib:ChangeSignalDisposition TestChildSignalDisposition
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+public class TestChildSignalDisposition {
+    // This test has two native parts:
+    // - a library injected into the JVM with -agentlib changes signal disposition of the VM process for SIGPIPE to
+    //   SIG_IGN
+    // - a small native executable that prints out, in its main function, all signal handler dispositions, to be executed
+    //   as a child process.
+    //
+    // What should happen: In child process, SIGPIPE should be set to default.
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createNativeTestProcessBuilder("PrintSignalDisposition");
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        output.shouldHaveExitValue(0);
+        output.shouldNotMatch("SIGPIPE: +ignore");
+        output.shouldNotMatch("SIGPIPE: +block");
+        output.shouldMatch("SIGPIPE: +default");
+        output.reportDiagnosticSummary();
+    }
+}

--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/exePrintSignalDisposition.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <errno.h>
+#include "jvmti.h"
+#include <signal.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static const struct { int sig; const char* name; } signals[] = {
+    { SIGABRT, "SIGABRT" }, { SIGALRM, "SIGALRM" }, { SIGBUS, "SIGBUS" }, { SIGCHLD, "SIGCHLD" }, { SIGCONT, "SIGCONT" },
+    { SIGFPE, "SIGFPE" }, { SIGHUP, "SIGHUP" }, { SIGILL, "SIGILL" }, { SIGINT, "SIGINT" }, { SIGKILL, "SIGKILL" },
+    { SIGPIPE, "SIGPIPE" }, { SIGQUIT, "SIGQUIT" }, { SIGSEGV, "SIGSEGV" }, { SIGSTOP, "SIGSTOP" }, { SIGTERM, "SIGTERM" },
+    { SIGTSTP, "SIGTSTP" }, { SIGTTIN, "SIGTTIN" }, { SIGTTOU, "SIGTTOU" }, { SIGUSR1, "SIGUSR1" }, { SIGUSR2, "SIGUSR2" },
+#ifdef SIGPOLL
+    { SIGPOLL, "SIGPOLL" },
+#endif
+    { SIGPROF, "SIGPROF" }, { SIGSYS, "SIGSYS" }, { SIGTRAP, "SIGTRAP" }, { SIGURG, "SIGURG" }, { SIGVTALRM, "SIGVTALRM" },
+    { SIGXCPU, "SIGXCPU" }, { SIGXFSZ, "SIGXFSZ" }, { -1, NULL }
+};
+
+int main(int argc, char** argv) {
+
+    printf("PID: %d\n", getpid());
+
+    sigset_t current_mask;
+    sigemptyset(&current_mask);
+    if (sigprocmask(SIG_BLOCK /* ignored */, NULL, &current_mask) != 0) {
+        printf("sigprocmask %d\n", errno);
+        return -1;
+    }
+
+    for (int n = 0; signals[n].sig != -1; n++) {
+        printf("%s: ", signals[n].name);
+        if (sigismember(&current_mask, signals[n].sig)) {
+            printf("blocked ");
+        }
+        struct sigaction act;
+        if (sigaction(signals[n].sig, NULL, &act) != 0) {
+            printf("sigaction %d\n", errno);
+            printf("\n");
+            continue;
+        }
+        const void* const handler = (act.sa_flags & SA_SIGINFO ?
+                                    (void*)act.sa_sigaction : (void*)act.sa_handler);
+        if (handler == (void*)SIG_DFL) {
+            printf("default ");
+        } else if (handler == (void*)SIG_IGN) {
+            printf("ignore ");
+        } else if (handler == (void*)SIG_HOLD) {
+            printf("hold ");
+        } else {
+            printf("%p ", handler);
+        }
+        printf("%X %X\n", act.sa_flags, act.sa_mask);
+    }
+
+    return 0;
+}

--- a/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/libChangeSignalDisposition.c
+++ b/test/jdk/java/lang/ProcessBuilder/childSignalDisposition/libChangeSignalDisposition.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <errno.h>
+#include "jvmti.h"
+#include <signal.h>
+#include <stdio.h>
+
+JNIEXPORT jint JNICALL
+Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
+
+  if (signal(SIGPIPE, SIG_IGN) != SIG_ERR) {
+    printf("changed signal disposition for SIGPIPE to SIG_IGN\n");
+  } else {
+    printf("FAILED to change signal disposition for SIGPIPE to SIG_IGN (%d)\n", errno);
+    return JNI_ERR;
+  }
+
+  return JNI_OK;
+}


### PR DESCRIPTION
Hi all,

Unclean (but trivial to merge) backport. Needed since we started seeing this at two customers now, and it makes sense to fix it at least in the upcoming newest LTS. 

- Tested on JDK25u on Linux x64 (ran java/lang/ProcessBuilder jtreg tests), which includes the provided regression test
- Will also run GHAs

This pull request contains a backport of commit [bdb1646a](https://github.com/openjdk/jdk/commit/bdb1646a1e39bae0535efe3f593e7fc0545e4114) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 11 Aug 2025 and was reviewed by Erik Joelsson and Roger Riggs.

Thanks!