### PR TITLE
8360783: CTW: Skip deoptimization between tiers

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/Compiler.java
@@ -202,17 +202,22 @@ public class Compiler {
 
         @Override
         public final void run() {
+            // Make sure method is not compiled at any level before starting
+            // progressive compilations. No deopt in-between tiers is needed,
+            // as long as we increase the compilation levels one by one.
+            WHITE_BOX.deoptimizeMethod(method);
+
             int compLevel = Utils.INITIAL_COMP_LEVEL;
             if (Utils.TIERED_COMPILATION) {
                 for (int i = compLevel; i <= Utils.TIERED_STOP_AT_LEVEL; ++i) {
-                    WHITE_BOX.deoptimizeMethod(method);
                     compileAtLevel(i);
                 }
             } else {
                 compileAtLevel(compLevel);
             }
 
-            // Make the method eligible for sweeping sooner
+            // Ditch all the compiled versions of the code, make the method
+            // eligible for sweeping sooner.
             WHITE_BOX.deoptimizeMethod(method);
         }
 


### PR DESCRIPTION
Massively improves CTW performance. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules` performance improves like in mainline
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8360783](https://bugs.openjdk.org/browse/JDK-8360783) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360783](https://bugs.openjdk.org/browse/JDK-8360783): CTW: Skip deoptimization between tiers (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/90.diff">https://git.openjdk.org/jdk25u/pull/90.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/90#issuecomment-3192116001)
</details>
