### PR TITLE
Backport ea754316fd6d691a701dfb4bc921ea8c92dc5dd4

### DIFF
--- a/src/hotspot/share/cds/cds_globals.hpp
+++ b/src/hotspot/share/cds/cds_globals.hpp
@@ -121,6 +121,7 @@
                                                                             \
   product(ccstr, AOTCacheOutput, nullptr,                                   \
           "Specifies the file name for writing the AOT cache")              \
+          constraint(AOTCacheOutputConstraintFunc, AtParse)                 \
                                                                             \
   product(bool, AOTInvokeDynamicLinking, false, DIAGNOSTIC,                 \
           "AOT-link JVM_CONSTANT_InvokeDynamic entries in cached "          \

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
@@ -39,6 +39,14 @@ JVMFlag::Error AOTCacheConstraintFunc(ccstr value, bool verbose) {
   return JVMFlag::SUCCESS;
 }
 
+JVMFlag::Error AOTCacheOutputConstraintFunc(ccstr value, bool verbose) {
+  if (value == nullptr) {
+    JVMFlag::printError(verbose, "AOTCacheOutput cannot be empty\n");
+    return JVMFlag::VIOLATES_CONSTRAINT;
+  }
+  return JVMFlag::SUCCESS;
+}
+
 JVMFlag::Error AOTConfigurationConstraintFunc(ccstr value, bool verbose) {
   if (value == nullptr) {
     JVMFlag::printError(verbose, "AOTConfiguration cannot be empty\n");

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.hpp
@@ -35,6 +35,7 @@
 
 #define RUNTIME_CONSTRAINTS(f)                        \
   f(ccstr,  AOTCacheConstraintFunc)                   \
+  f(ccstr,  AOTCacheOutputConstraintFunc)             \
   f(ccstr,  AOTConfigurationConstraintFunc)           \
   f(ccstr,  AOTModeConstraintFunc)                    \
   f(int,    ObjectAlignmentInBytesConstraintFunc)     \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotFlags/AOTFlags.java
@@ -484,6 +484,7 @@ public class AOTFlags {
         testEmptyValue("AOTCache");
         testEmptyValue("AOTConfiguration");
         testEmptyValue("AOTMode");
+        testEmptyValue("AOTCacheOutput");
     }
 
     static void testEmptyValue(String option) throws Exception {


### PR DESCRIPTION
Plugs the UX problem with new feature in JDK 25.

Additional testing:
 - [x] Linux x86_64 server fastdebug, new regression test fails without the patch, passes with it
 - [x] Linux x86_64 server fastdebug, ad-hoc tests