### PR TITLE
8365468: EagerJVMCI should only apply to the CompilerBroker JVMCI runtime

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -186,7 +186,10 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
                         // Can only do eager initialization of the JVMCI compiler
                         // once the singleton instance is available.
                         if (result.config.getFlag("EagerJVMCI", Boolean.class)) {
-                            result.getCompiler();
+                            // EagerJVMCI only applies to JVMCI when used by the CompileBroker.
+                            if (result.getCompilerToVM().isCompilerThread()) {
+                                result.getCompiler();
+                            }
                         }
                     }
                     // Ensures JVMCIRuntime::_HotSpotJVMCIRuntime_instance is


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [e3aeebec](https://github.com/openjdk/jdk/commit/e3aeebec1798b9adbb02e11f285951d4275c52e8) ([pull request](https://github.com/openjdk/jdk/pull/26768)) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Doug Simon on 15 Aug 2025 and was reviewed by Tom Rodriguez.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8365468](https://bugs.openjdk.org/browse/JDK-8365468) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365468](https://bugs.openjdk.org/browse/JDK-8365468): EagerJVMCI should only apply to the CompilerBroker JVMCI runtime (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/92/head:pull/92` \
`$ git checkout pull/92`

Update a local copy of the PR: \
`$ git checkout pull/92` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/92/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 92`

View PR using the GUI difftool: \
`$ git pr show -t 92`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/92.diff">https://git.openjdk.org/jdk25u/pull/92.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/92#issuecomment-3195766668)
</details>
