### PR TITLE
8357382: runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java#aot fails with Xcomp and C1

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java
@@ -78,6 +78,7 @@ import java.io.File;
 import java.lang.StackWalker.StackFrame;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -318,12 +319,15 @@ class BulkLoaderTestApp {
         }
     }
 
+    static ArrayList<ClassLoader> savedLoaders = new ArrayList<>();
+
     static Object initFromCustomLoader() throws Exception {
         String path = "cust.jar";
         URL url = new File(path).toURI().toURL();
         URL[] urls = new URL[] {url};
         URLClassLoader urlClassLoader =
             new URLClassLoader("MyLoader", urls, null);
+        savedLoaders.add(urlClassLoader);
         Class c = Class.forName("SimpleCusty", true, urlClassLoader);
         return c.newInstance();
     }


### PR DESCRIPTION
Stabilizes newly added test in JDK 25.

Additional testing:
 - [x] MacOS AArch64 server fastdebug, affected test passes with 100x iterations

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8357382](https://bugs.openjdk.org/browse/JDK-8357382) needs maintainer approval

### Issue
 * [JDK-8357382](https://bugs.openjdk.org/browse/JDK-8357382): runtime/cds/appcds/aotClassLinking/BulkLoaderTest.java#aot fails with Xcomp and C1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/95.diff">https://git.openjdk.org/jdk25u/pull/95.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/95#issuecomment-3197769862)
</details>
