### PR TITLE
8361112: Use exact float -> Float16 conversion method in Float16 tests

### DIFF
--- a/test/jdk/jdk/incubator/vector/BasicFloat16ArithTests.java
+++ b/test/jdk/jdk/incubator/vector/BasicFloat16ArithTests.java
@@ -186,7 +186,7 @@ public class BasicFloat16ArithTests {
         for(var testCase : testCases) {
             float arg =      testCase[0];
             float expected = testCase[1];
-            Float16 result =  negate(valueOf(arg));
+            Float16 result =  negate(valueOfExact(arg));
 
             if (Float.compare(expected, result.floatValue()) != 0) {
                 checkFloat16(result, expected, "negate(" + arg + ")");
@@ -213,7 +213,7 @@ public class BasicFloat16ArithTests {
         for(var testCase : testCases) {
             float arg =      testCase[0];
             float expected = testCase[1];
-            Float16 result =  abs(valueOf(arg));
+            Float16 result =  abs(valueOfExact(arg));
 
             if (Float.compare(expected, result.floatValue()) != 0) {
                 checkFloat16(result, expected, "abs(" + arg + ")");
@@ -238,7 +238,7 @@ public class BasicFloat16ArithTests {
         };
 
         for(var testCase : testCases) {
-            boolean result = isNaN(valueOf(testCase));
+            boolean result = isNaN(valueOfExact(testCase));
             if (result) {
                 throwRE("isNaN returned true for " + testCase);
             }
@@ -254,8 +254,8 @@ public class BasicFloat16ArithTests {
         };
 
         for(var infinity : infinities) {
-            boolean result1 = isFinite(valueOf(infinity));
-            boolean result2 = isInfinite(valueOf(infinity));
+            boolean result1 = isFinite(valueOfExact(infinity));
+            boolean result2 = isInfinite(valueOfExact(infinity));
 
             if (result1) {
                 throwRE("Float16.isFinite returned true for " + infinity);
@@ -282,8 +282,8 @@ public class BasicFloat16ArithTests {
         };
 
         for(var finity : finities) {
-            boolean result1 = isFinite(valueOf(finity));
-            boolean result2 = isInfinite(valueOf(finity));
+            boolean result1 = isFinite(valueOfExact(finity));
+            boolean result2 = isInfinite(valueOfExact(finity));
 
             if (!result1) {
                 throwRE("Float16.isFinite returned true for " + finity);
@@ -301,12 +301,12 @@ public class BasicFloat16ArithTests {
         float small = 1.0f;
         float large = 2.0f;
 
-        if (min(valueOf(small), valueOf(large)).floatValue() != small) {
+        if (min(valueOfExact(small), valueOfExact(large)).floatValue() != small) {
             throwRE(String.format("min(%g, %g) not equal to %g)",
                                   small, large, small));
         }
 
-        if (max(valueOf(small), valueOf(large)).floatValue() != large) {
+        if (max(valueOfExact(small), valueOfExact(large)).floatValue() != large) {
             throwRE(String.format("max(%g, %g) not equal to %g)",
                                   small, large, large));
         }
@@ -318,10 +318,10 @@ public class BasicFloat16ArithTests {
      */
     private static void checkArith() {
         float   a   = 1.0f;
-        Float16 a16 = valueOf(a);
+        Float16 a16 = valueOfExact(a);
 
         float   b   = 2.0f;
-        Float16 b16 = valueOf(b);
+        Float16 b16 = valueOfExact(b);
 
         if (add(a16, b16).floatValue() != (a + b)) {
             throwRE("failure with " + a16 + " + " + b16);
@@ -371,7 +371,7 @@ public class BasicFloat16ArithTests {
         for(var testCase : testCases) {
             float arg =      testCase[0];
             float expected = testCase[1];
-            Float16 result =  sqrt(valueOf(arg));
+            Float16 result =  sqrt(valueOfExact(arg));
 
             if (Float.compare(expected, result.floatValue()) != 0) {
                 checkFloat16(result, expected, "sqrt(" + arg + ")");
@@ -409,7 +409,7 @@ public class BasicFloat16ArithTests {
             float arg =      testCase[0];
             float expected = testCase[1];
             // Exponents are in-range for Float16
-            Float16 result =  valueOf(getExponent(valueOf(arg)));
+            Float16 result =  valueOfExact(getExponent(valueOfExact(arg)));
 
             if (Float.compare(expected, result.floatValue()) != 0) {
                 checkFloat16(result, expected, "getExponent(" + arg + ")");
@@ -445,7 +445,7 @@ public class BasicFloat16ArithTests {
             float arg =      testCase[0];
             float expected = testCase[1];
             // Exponents are in-range for Float16
-            Float16 result =  ulp(valueOf(arg));
+            Float16 result =  ulp(valueOfExact(arg));
 
             if (Float.compare(expected, result.floatValue()) != 0) {
                 checkFloat16(result, expected, "ulp(" + arg + ")");
@@ -602,7 +602,7 @@ public class BasicFloat16ArithTests {
             String input = testCase.input();
             float expected = testCase.expected();
             Float16 result = Float16.valueOf(input);
-            checkFloat16(result, expected, "Float16.valueOf(String) " + input);
+            checkFloat16(result, expected, "Float16.valueOfExact(String) " + input);
         }
 
         List<String> negativeCases = List.of("0x1",
@@ -747,7 +747,7 @@ public class BasicFloat16ArithTests {
         }
 
         private static void testSimple() {
-            final float ulpOneFp16 = ulp(valueOf(1.0f)).floatValue();
+            final float ulpOneFp16 = ulp(valueOfExact(1.0f)).floatValue();
 
             float [][] testCases = {
                 {1.0f, 2.0f, 3.0f,
@@ -781,7 +781,7 @@ public class BasicFloat16ArithTests {
         }
 
         private static void testRounding() {
-            final float ulpOneFp16 = ulp(valueOf(1.0f)).floatValue();
+            final float ulpOneFp16 = ulp(valueOfExact(1.0f)).floatValue();
 
             float [][] testCases = {
                 // The product is equal to
@@ -839,10 +839,10 @@ public class BasicFloat16ArithTests {
         }
 
         private static void testFusedMacCase(float input1, float input2, float input3, float expected) {
-            Float16 a = valueOf(input1);
-            Float16 b = valueOf(input2);
-            Float16 c = valueOf(input3);
-            Float16 d = valueOf(expected);
+            Float16 a = valueOfExact(input1);
+            Float16 b = valueOfExact(input2);
+            Float16 c = valueOfExact(input3);
+            Float16 d = valueOfExact(expected);
 
             test("Float16.fma(float)", a, b, c, Float16.fma(a, b, c), d);
 
@@ -864,5 +864,21 @@ public class BasicFloat16ArithTests {
                                "\tgot       "  + result   + "\t(" + toHexString(result) + ").");
             throw new RuntimeException();
         }
+    }
+
+    /**
+     * {@return a Float16 value converted from the {@code float}
+     * argument throwing an {@code ArithmeticException} if the
+     * conversion is inexact}.
+     *
+     * @param f the {@code float} value to convert exactly
+     * @throws ArithmeticException
+     */
+    private static Float16 valueOfExact(float f) {
+        Float16 f16 = valueOf(f);
+        if (Float.compare(f16.floatValue(), f) != 0) {
+            throw new ArithmeticException("Inexact conversion to Float16 of float value " + f);
+        }
+        return f16;
     }
 }


### PR DESCRIPTION
jdk-25.0.1/bin/java -jar jtreg7.5.2/jtreg/lib/jtreg.jar -testjdk:jdk-25.0.1 -verbose:summary -dir:jdk25u-cpu/open/test/jdk/ jdk/incubator/vector/BasicFloat16ArithTests.java
Passed: jdk/incubator/vector/BasicFloat16ArithTests.java
Test results: passed: 1
Report written to C:\jck\colocation\JTreport\html\report.html
Results written to C:\jck\colocation\JTwork

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361112](https://bugs.openjdk.org/browse/JDK-8361112) needs maintainer approval

### Issue
 * [JDK-8361112](https://bugs.openjdk.org/browse/JDK-8361112): Use exact float -&gt; Float16 conversion method in Float16 tests (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/98.diff">https://git.openjdk.org/jdk25u/pull/98.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/98#issuecomment-3198386772)
</details>
