### PR TITLE
8359947: GenShen: use smaller TLABs by default

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -184,9 +184,10 @@ void ShenandoahArguments::initialize() {
   // Current default is good for generational collectors that run frequent young GCs.
   // With Shenandoah, GC cycles are much less frequent, so we need we need sizing policy
   // to converge faster over smaller number of resizing decisions.
-  if (FLAG_IS_DEFAULT(TLABAllocationWeight)) {
+  if (strcmp(ShenandoahGCMode, "generational") && FLAG_IS_DEFAULT(TLABAllocationWeight)) {
     FLAG_SET_DEFAULT(TLABAllocationWeight, 90);
   }
+  // In generational mode, let TLABAllocationWeight keeps its default value of 35.
 
   if (GCCardSizeInBytes < ShenandoahMinCardSizeInBytes) {
     vm_exit_during_initialization(
@@ -217,6 +218,10 @@ void ShenandoahArguments::initialize_alignments() {
   }
   SpaceAlignment = align;
   HeapAlignment = align;
+
+  if (FLAG_IS_DEFAULT(TLABSize)) {
+    TLABSize = MAX2(ShenandoahHeapRegion::region_size_bytes() / 256, (size_t) 32 * 1024);
+  }
 }
 
 CollectedHeap* ShenandoahArguments::create_heap() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -790,8 +790,10 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
   RegionCount = align_up(max_heap_size, RegionSizeBytes) / RegionSizeBytes;
   guarantee(RegionCount >= MIN_NUM_REGIONS, "Should have at least minimum regions");
 
+  // Limit TLAB size for better startup behavior and more equitable distribution of memory between contending mutator threads.
   guarantee(MaxTLABSizeWords == 0, "we should only set it once");
-  MaxTLABSizeWords = align_down(RegionSizeWords, MinObjAlignment);
+  MaxTLABSizeWords = align_down(MIN2(RegionSizeWords, MAX2(RegionSizeWords / 32, (size_t) (256 * 1024) / HeapWordSize)),
+                                MinObjAlignment);
 
   guarantee(MaxTLABSizeBytes == 0, "we should only set it once");
   MaxTLABSizeBytes = MaxTLABSizeWords * HeapWordSize;

--- a/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
+++ b/test/hotspot/jtreg/gc/shenandoah/generational/TestOldGrowthTriggers.java
@@ -57,17 +57,17 @@ public class TestOldGrowthTriggers {
             for (int i = 0; i < ArraySize; i++) {
                 int replaceIndex = r.nextInt(ArraySize);
                 int deriveIndex = r.nextInt(ArraySize);
-                switch (i & 0x3) {
-                    case 0:
+                switch (i & 0x7) {
+                    case 0,1,2:
                         // creates new old BigInteger, releases old BigInteger,
                         // may create ephemeral data while computing gcd
                         array[replaceIndex] = array[replaceIndex].gcd(array[deriveIndex]);
                         break;
-                    case 1:
+                    case 3,4:
                         // creates new old BigInteger, releases old BigInteger
                         array[replaceIndex] = array[replaceIndex].multiply(array[deriveIndex]);
                         break;
-                    case 2,3:
+                    case 5,6,7:
                         // do nothing, let all objects in the array age to increase pressure on old generation
                         break;
                 }


### PR DESCRIPTION
Clean backport. This is a performance improvement for the generational mode of Shenandoah.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359947](https://bugs.openjdk.org/browse/JDK-8359947) needs maintainer approval

### Issue
 * [JDK-8359947](https://bugs.openjdk.org/browse/JDK-8359947): GenShen: use smaller TLABs by default (**Task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/99.diff">https://git.openjdk.org/jdk25u/pull/99.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/99#issuecomment-3198428927)
</details>
