### PR TITLE
8365071: ARM32: JFR intrinsic jvm_commit triggers C2 regalloc assert

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3245,7 +3245,7 @@ bool LibraryCallKit::inline_native_jvm_commit() {
   lease_compare_io->init_req(_true_path, i_o());
   lease_compare_io->init_req(_false_path, input_io_state);
 
-  lease_result_value->init_req(_true_path, null()); // if the lease was returned, return 0.
+  lease_result_value->init_req(_true_path, _gvn.longcon(0)); // if the lease was returned, return 0L.
   lease_result_value->init_req(_false_path, arg); // if not lease, return new updated position.
 
   RegionNode* result_rgn = new RegionNode(PATH_LIMIT);


### PR DESCRIPTION
Corrects a minor flaw in the jvm_commit JFR intrinsic that triggers a C2 assertion failure on ARM32.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365071](https://bugs.openjdk.org/browse/JDK-8365071) needs maintainer approval

### Issue
 * [JDK-8365071](https://bugs.openjdk.org/browse/JDK-8365071): ARM32: JFR intrinsic jvm_commit triggers C2 regalloc assert (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/104.diff">https://git.openjdk.org/jdk25u/pull/104.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/104#issuecomment-3200812804)
</details>
