### PR TITLE
8358048: java/net/httpclient/HttpsTunnelAuthTest.java incorrectly calls Thread::stop

### DIFF
--- a/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
+++ b/test/jdk/java/net/httpclient/HttpsTunnelAuthTest.java
@@ -37,12 +37,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.http2.Http2TestServer;
 import jdk.test.lib.net.SimpleSSLContext;
 
 import static java.lang.System.out;
 
-/**
+/*
  * @test
  * @bug 8262027
  * @summary Verify that it's possible to handle proxy authentication manually
@@ -62,7 +61,7 @@ import static java.lang.System.out;
 //-Djdk.internal.httpclient.debug=true -Dtest.debug=true
 public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
 
-    static final String data[] = {
+    static final String[] data = {
         "Lorem ipsum",
         "dolor sit amet",
         "consectetur adipiscing elit, sed do eiusmod tempor",
@@ -150,7 +149,7 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        if (proxy != null) close(proxy::stop);
+        if (proxy != null) close(proxy);
         if (http1Server != null) close(http1Server::stop);
         if (https1Server != null) close(https1Server::stop);
         if (https2Server != null) close(https2Server::stop);
@@ -160,7 +159,8 @@ public class HttpsTunnelAuthTest implements HttpServerAdapters, AutoCloseable {
         try {
             closeable.close();
         } catch (Exception x) {
-            // OK.
+            // OK to ignore and just log
+            System.err.println("ignoring failure during close() of " + closeable + " due to: " + x);
         }
     }
 


### PR DESCRIPTION
Tested local changes and no failure observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358048](https://bugs.openjdk.org/browse/JDK-8358048) needs maintainer approval

### Issue
 * [JDK-8358048](https://bugs.openjdk.org/browse/JDK-8358048): java/net/httpclient/HttpsTunnelAuthTest.java incorrectly calls Thread::stop (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/111.diff">https://git.openjdk.org/jdk25u/pull/111.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/111#issuecomment-3204354802)
</details>
