### PR TITLE
8362207: Add more test cases for possible double-rounding in fma

### DIFF
--- a/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
+++ b/test/jdk/java/lang/Math/FusedMultiplyAddTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4851642 8253409
+ * @bug 4851642 8253409 8362207
  * @summary Tests for Math.fusedMac and StrictMath.fusedMac.
  * @build Tests
  * @build FusedMultiplyAddTests
@@ -352,8 +352,9 @@ public class FusedMultiplyAddTests {
             {1.0f+Math.ulp(1.0f), 1.0f+Math.ulp(1.0f), -1.0f-2.0f*Math.ulp(1.0f),
              Math.ulp(1.0f)*Math.ulp(1.0f)},
 
-            // Double-rounding if done in double precision
-            {0x1.fffffep23f, 0x1.000004p28f, 0x1.fep5f, 0x1.000002p52f}
+            // Double-rounding if done in double precision and/or double fma
+            {0x1.fffffep23f, 0x1.000004p28f, 0x1.fep5f, 0x1.000002p52f},
+            {0x1.001p0f,     0x1.001p0f,     0x1p-100f, 0x1.002002p0f},
         };
 
         for (float[] testCase: testCases)

--- a/test/jdk/jdk/incubator/vector/BasicFloat16ArithTests.java
+++ b/test/jdk/jdk/incubator/vector/BasicFloat16ArithTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8329817 8334432 8339076 8341260
+ * @bug 8329817 8334432 8339076 8341260 8362207
  * @modules jdk.incubator.vector
  * @summary Basic tests of Float16 arithmetic and similar operations
  */
@@ -815,6 +815,11 @@ public class BasicFloat16ArithTests {
 
                 {0x1.ffcp-14f, 0x1.0p-24f, 0x1.0p14f, // *Cannot* be held exactly
                  0x1.0p14f},
+
+                // Arguments where using float fma or uniform float
+                // arithmetic gives the wrong result
+                {0x1.08p7f, 0x1.04p7f, 0x1.0p-24f,
+                 0x1.0c4p14f},
 
                 // Check values where the exact result cannot be
                 // exactly stored in a double.


### PR DESCRIPTION
jdk-25.0.1/bin/java -jar jtreg7.5.2/jtreg/lib/jtreg.jar -testjdk:jdk-25.0.1 -verbose:summary -dir:jdk25u-cpu/open/test/jdk/ java/lang/Math/FusedMultiplyAddTests.java jdk/incubator/vector/BasicFloat16ArithTests.java
Passed: java/lang/Math/FusedMultiplyAddTests.java
Passed: jdk/incubator/vector/BasicFloat16ArithTests.java
Test results: passed: 2
Report written to C:\jck\colocation\JTreport\html\report.html
Results written to C:\jck\colocation\JTwork

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362207](https://bugs.openjdk.org/browse/JDK-8362207) needs maintainer approval

### Issue
 * [JDK-8362207](https://bugs.openjdk.org/browse/JDK-8362207): Add more test cases for possible double-rounding in fma (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/114/head:pull/114` \
`$ git checkout pull/114`

Update a local copy of the PR: \
`$ git checkout pull/114` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 114`

View PR using the GUI difftool: \
`$ git pr show -t 114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/114.diff">https://git.openjdk.org/jdk25u/pull/114.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/114#issuecomment-3204456977)
</details>
