### PR TITLE
8362889: [GCC static analyzer] leak in libstringPlatformChars.c

### DIFF
--- a/test/jdk/java/lang/String/nativeEncoding/libstringPlatformChars.c
+++ b/test/jdk/java/lang/String/nativeEncoding/libstringPlatformChars.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,11 +58,13 @@ Java_StringPlatformChars_newString(JNIEnv *env, jclass unused, jbyteArray bytes)
     char* str;
     int len = (*env)->GetArrayLength(env, bytes);
     int i;
-    jbyte* jbytes;
-
-    str = (char*)malloc(len + 1);
-    jbytes = (*env)->GetPrimitiveArrayCritical(env, bytes, NULL);
+    jbyte* jbytes = (*env)->GetPrimitiveArrayCritical(env, bytes, NULL);
     if (jbytes == NULL) {
+        return NULL;
+    }
+    str = (char*)malloc(len + 1);
+    if (str == NULL) {
+        (*env)->ReleasePrimitiveArrayCritical(env, bytes, (void*)jbytes, 0);
         return NULL;
     }
     for (i = 0; i < len; i++) {
@@ -71,6 +73,8 @@ Java_StringPlatformChars_newString(JNIEnv *env, jclass unused, jbyteArray bytes)
     str[len] = '\0';
     (*env)->ReleasePrimitiveArrayCritical(env, bytes, (void*)jbytes, 0);
 
-    return JNU_NewStringPlatform(env, str);
+    jstring res = JNU_NewStringPlatform(env, str);
+    free(str);
+    return res;
 }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362889](https://bugs.openjdk.org/browse/JDK-8362889) needs maintainer approval

### Issue
 * [JDK-8362889](https://bugs.openjdk.org/browse/JDK-8362889): [GCC static analyzer] leak in libstringPlatformChars.c (**Bug** - P4 - Approved)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/116/head:pull/116` \
`$ git checkout pull/116`

Update a local copy of the PR: \
`$ git checkout pull/116` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 116`

View PR using the GUI difftool: \
`$ git pr show -t 116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/116.diff">https://git.openjdk.org/jdk25u/pull/116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/116#issuecomment-3204771930)
</details>
