### PR TITLE
8365543: UnixNativeDispatcher.init should lookup open64at and stat64at on AIX

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -343,22 +343,21 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
 
     /* system calls that might not be available at run time */
 
-#if defined(_ALLBSD_SOURCE)
-    my_openat_func = (openat_func*) openat;
-    my_fstatat_func = (fstatat_func*) fstatat;
-#else
-    // Make sure we link to the 64-bit version of the functions
-    my_openat_func = (openat_func*) dlsym(RTLD_DEFAULT, "openat64");
-    my_fstatat_func = (fstatat_func*) dlsym(RTLD_DEFAULT, "fstatat64");
-#endif
     my_unlinkat_func = (unlinkat_func*) dlsym(RTLD_DEFAULT, "unlinkat");
     my_renameat_func = (renameat_func*) dlsym(RTLD_DEFAULT, "renameat");
 #if defined(_AIX)
     // Make sure we link to the 64-bit version of the function
+    my_openat_func = (openat_func*) dlsym(RTLD_DEFAULT, "open64at");
+    my_fstatat_func = (fstatat_func*) dlsym(RTLD_DEFAULT, "stat64at");
     my_fdopendir_func = (fdopendir_func*) dlsym(RTLD_DEFAULT, "fdopendir64");
 #elif defined(_ALLBSD_SOURCE)
+    my_openat_func = (openat_func*) openat;
+    my_fstatat_func = (fstatat_func*) fstatat;
     my_fdopendir_func = (fdopendir_func*) fdopendir;
 #else
+    // Make sure we link to the 64-bit version of the functions
+    my_openat_func = (openat_func*) dlsym(RTLD_DEFAULT, "openat64");
+    my_fstatat_func = (fstatat_func*) dlsym(RTLD_DEFAULT, "fstatat64");
     my_fdopendir_func = (fdopendir_func*) dlsym(RTLD_DEFAULT, "fdopendir");
 #endif
 

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -24,7 +24,7 @@
 /* @test
  * @bug 4313887 6838333 8343020 8357425
  * @summary Unit test for java.nio.file.SecureDirectoryStream
- * @requires (os.family == "linux" | os.family == "mac")
+ * @requires (os.family == "linux" | os.family == "mac" | os.family == "aix")
  * @library .. /test/lib
  * @build jdk.test.lib.Platform
  * @run main SecureDS


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365543](https://bugs.openjdk.org/browse/JDK-8365543) needs maintainer approval

### Issue
 * [JDK-8365543](https://bugs.openjdk.org/browse/JDK-8365543): UnixNativeDispatcher.init should lookup open64at and stat64at on AIX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/119/head:pull/119` \
`$ git checkout pull/119`

Update a local copy of the PR: \
`$ git checkout pull/119` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 119`

View PR using the GUI difftool: \
`$ git pr show -t 119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/119.diff">https://git.openjdk.org/jdk25u/pull/119.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/119#issuecomment-3205680355)
</details>
