### PR TITLE
8365841: RISC-V: Several IR verification tests fail after JDK-8350960 without Zvfh

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -110,6 +110,7 @@ source %{
         if (vlen < 4) {
           return false;
         }
+        break;
       case Op_VectorCastHF2F:
       case Op_VectorCastF2HF:
       case Op_AddVHF:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2e06a917](https://github.com/openjdk/jdk/commit/2e06a917659d76fa1b4c63f38894564679209625) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 21 Aug 2025 and was reviewed by Fei Yang, Feilong Jiang and Hamlin Li.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365841](https://bugs.openjdk.org/browse/JDK-8365841) needs maintainer approval

### Issue
 * [JDK-8365841](https://bugs.openjdk.org/browse/JDK-8365841): RISC-V: Several IR verification tests fail after JDK-8350960 without Zvfh (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/122/head:pull/122` \
`$ git checkout pull/122`

Update a local copy of the PR: \
`$ git checkout pull/122` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 122`

View PR using the GUI difftool: \
`$ git pr show -t 122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/122.diff">https://git.openjdk.org/jdk25u/pull/122.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/122#issuecomment-3208635712)
</details>
