### PR TITLE
8365844: RISC-V: TestBadFormat.java fails when running without RVV

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestBadFormat.java
@@ -1124,8 +1124,8 @@ class BadIRAnnotationsAfterTestVM {
 
     @Test
     @FailCount(8)
-    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"})
-    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}) // valid
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 0"}, applyIf = {"MaxVectorSize", "> 0"}) // valid, but only if MaxVectorSize > 0, otherwise, a violation is reported
+    @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_MAX, "> 0"}, applyIf = {"MaxVectorSize", "> 0"}) // valid, but only if MaxVectorSize > 0, otherwise, a violation is reported
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE_ANY, "> 0"}) // valid
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "", "> 0"})
     @IR(counts = {IRNode.LOAD_VECTOR_I, IRNode.VECTOR_SIZE + "xxx", "> 0"})


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [584137cf](https://github.com/openjdk/jdk/commit/584137cf968bdfd4fdb88b5bb210bbbfa5f2d537) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 22 Aug 2025 and was reviewed by Feilong Jiang, Christian Hagedorn, Emanuel Peter and Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365844](https://bugs.openjdk.org/browse/JDK-8365844) needs maintainer approval

### Issue
 * [JDK-8365844](https://bugs.openjdk.org/browse/JDK-8365844): RISC-V: TestBadFormat.java fails when running without RVV (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/124.diff">https://git.openjdk.org/jdk25u/pull/124.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/124#issuecomment-3212834930)
</details>
