### PR TITLE
8356324: JVM crash (SIGSEGV at ClassListParser::resolve_indy_impl) during -Xshare:dump starting from 21.0.5

### DIFF
--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -73,6 +73,9 @@ inline ResolvedIndyEntry* ConstantPoolCache::resolved_indy_entry_at(int index) c
 }
 
 inline int ConstantPoolCache::resolved_indy_entries_length() const {
+  if (_resolved_indy_entries == nullptr) {
+    return 0;
+  }
   return _resolved_indy_entries->length();
 }
 #endif // SHARE_OOPS_CPCACHE_INLINE_HPP


### PR DESCRIPTION
Avoids the JVM crash in a corner case. The patch is very recent, but it is borderline trivial, and we have seen customer crashes in the wild (see original issue). Without the patch, the alternative on this code path is a JVM crash.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8356324](https://bugs.openjdk.org/browse/JDK-8356324) needs maintainer approval

### Issue
 * [JDK-8356324](https://bugs.openjdk.org/browse/JDK-8356324): JVM crash (SIGSEGV at ClassListParser::resolve_indy_impl) during -Xshare:dump starting from 21.0.5 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/127/head:pull/127` \
`$ git checkout pull/127`

Update a local copy of the PR: \
`$ git checkout pull/127` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 127`

View PR using the GUI difftool: \
`$ git pr show -t 127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/127.diff">https://git.openjdk.org/jdk25u/pull/127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/127#issuecomment-3219560558)
</details>
