### PR TITLE
8354646: java.awt.TextField allows to identify the spaces in a password when double clicked at the starting and end of the text

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPasswordFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicPasswordFieldUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,23 +91,4 @@ public class BasicPasswordFieldUI extends BasicTextFieldUI {
     public View create(Element elem) {
         return new PasswordView(elem);
     }
-
-    /**
-     * Create the action map for Password Field.  This map provides
-     * same actions for double mouse click and
-     * and for triple mouse click (see bug 4231444).
-     */
-
-    ActionMap createActionMap() {
-        ActionMap map = super.createActionMap();
-        if (map.get(DefaultEditorKit.selectWordAction) != null) {
-            Action a = map.get(DefaultEditorKit.selectLineAction);
-            if (a != null) {
-                map.remove(DefaultEditorKit.selectWordAction);
-                map.put(DefaultEditorKit.selectWordAction, a);
-            }
-        }
-        return map;
-    }
-
 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicTextUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -647,6 +647,22 @@ public abstract class BasicTextUI extends TextUI implements ViewFactory {
                 TransferHandler.getCopyAction());
         map.put(TransferHandler.getPasteAction().getValue(Action.NAME),
                 TransferHandler.getPasteAction());
+
+        if (getComponent() instanceof JPasswordField) {
+            // Edit the action map for Password Field.  This map provides
+            // same actions for double mouse click and
+            // and for triple mouse click (see bugs 4231444, 8354646).
+
+            if (map.get(DefaultEditorKit.selectWordAction) != null) {
+                map.remove(DefaultEditorKit.selectWordAction);
+
+                Action a = map.get(DefaultEditorKit.selectLineAction);
+                if (a != null) {
+                    map.put(DefaultEditorKit.selectWordAction, a);
+                }
+            }
+        }
+
         return map;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPasswordFieldUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthPasswordFieldUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,20 +107,5 @@ public class SynthPasswordFieldUI extends SynthTextFieldUI {
     public void paintBorder(SynthContext context, Graphics g, int x,
                             int y, int w, int h) {
         context.getPainter().paintPasswordFieldBorder(context, g, x, y, w, h);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected void installKeyboardActions() {
-        super.installKeyboardActions();
-        ActionMap map = SwingUtilities.getUIActionMap(getComponent());
-        if (map != null && map.get(DefaultEditorKit.selectWordAction) != null) {
-            Action a = map.get(DefaultEditorKit.selectLineAction);
-            if (a != null) {
-                map.put(DefaultEditorKit.selectWordAction, a);
-            }
-        }
     }
 }

--- a/test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import jdk.test.lib.Platform;
 
 /*
  * @test
- * @bug 6191897
+ * @bug 6191897 8354646
  * @summary Verifies that ctrl+left/right does not move word-by-word in a TextField
  *          with echo character set
  * @library /java/awt/regtesthelpers  /test/lib

--- a/test/jdk/javax/swing/plaf/basic/BasicTextUI/PasswordSelectionWordTest.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicTextUI/PasswordSelectionWordTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @key headful
+ * @bug 4231444 8354646
+ * @summary Password fields' ActionMap needs to replace
+ *          DefaultEditorKit.selectWordAction with
+ *          DefaultEditorKit.selectLineAction.
+ *
+ * @run main PasswordSelectionWordTest
+ */
+
+import javax.swing.Action;
+import javax.swing.JPasswordField;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.plaf.basic.BasicTextUI;
+import javax.swing.text.DefaultEditorKit;
+import java.awt.event.ActionEvent;
+
+public class PasswordSelectionWordTest {
+    public static void main(String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf :
+                UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing LAF: " + laf.getClassName());
+            SwingUtilities.invokeAndWait(() -> {
+                if (setLookAndFeel(laf)) {
+                    runTest();
+                }
+            });
+        }
+    }
+
+    private static boolean setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+            return true;
+        } catch (UnsupportedLookAndFeelException  e) {
+            System.err.println("Skipping unsupported look and feel:");
+            e.printStackTrace();
+            return false;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void runTest() {
+        String str = "one two three";
+        JPasswordField field = new JPasswordField(str);
+        if (!(field.getUI() instanceof BasicTextUI)) {
+            throw new RuntimeException("Unexpected condition: JPasswordField UI was " + field.getUI());
+        }
+        System.out.println("Testing " + field.getUI());
+
+        // do something (anything) to initialize the Views:
+        field.setSize(100, 100);
+        field.addNotify();
+
+        Action action = field.getActionMap().get(
+                DefaultEditorKit.selectWordAction);
+        action.actionPerformed(new ActionEvent(field, 0, ""));
+        int selectionStart = field.getSelectionStart();
+        int selectionEnd = field.getSelectionEnd();
+        System.out.println("selectionStart = " + selectionStart);
+        System.out.println("selectionEnd = " + selectionEnd);
+        if (selectionStart != 0 || selectionEnd != str.length()) {
+            throw new RuntimeException("selectionStart = " + selectionStart +
+                    " and selectionEnd = " + selectionEnd);
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains a backport of commit [8d33ea73](https://github.com/openjdk/jdk/commit/8d33ea7395e5dd504b899d8972617f6696546d84) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by jeremy on 12 Jun 2025 and was reviewed by Alexey Ivanov, Alexander Zuev, Tejesh R and Prasanta Sadhukhan.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354646](https://bugs.openjdk.org/browse/JDK-8354646) needs maintainer approval

### Issue
 * [JDK-8354646](https://bugs.openjdk.org/browse/JDK-8354646): java.awt.TextField allows to identify the spaces in a password when double clicked at the starting and end of the text (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/133.diff">https://git.openjdk.org/jdk25u/pull/133.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/133#issuecomment-3220401909)
</details>
