### PR TITLE
8349188: LineBorder does not scale correctly

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/border/LineBorder.java
+++ b/src/java.desktop/share/classes/javax/swing/border/LineBorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ import java.awt.geom.RoundRectangle2D;
 import java.beans.ConstructorProperties;
 
 import com.sun.java.swing.SwingUtilities3;
+
+import static sun.java2d.pipe.Region.clipRound;
 
 /**
  * A class which implements a line border of arbitrary thickness
@@ -161,7 +163,7 @@ public class LineBorder extends AbstractBorder
             Shape outer;
             Shape inner;
 
-            int offs = this.thickness * (int) scaleFactor;
+            int offs = clipRound(this.thickness * scaleFactor);
             int size = offs + offs;
             if (this.roundedCorners) {
                 float arc = .2f * offs;

--- a/test/jdk/javax/swing/border/LineBorder/ScaledTextFieldBorderTest.java
+++ b/test/jdk/javax/swing/border/LineBorder/ScaledTextFieldBorderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,12 +44,15 @@ import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 
+import static sun.java2d.pipe.Region.clipRound;
+
 /*
  * @test
- * @bug 8282958
+ * @bug 8282958 8349188
  * @summary Verify all the borders are rendered consistently for a JTextField
  *          in Windows LaF which uses LineBorder
  * @requires (os.family == "windows")
+ * @modules java.desktop/sun.java2d.pipe
  * @run main ScaledTextFieldBorderTest
  */
 public class ScaledTextFieldBorderTest {
@@ -92,7 +95,7 @@ public class ScaledTextFieldBorderTest {
             BufferedImage img = images.get(i);
             double scaling = scales[i];
             try {
-                int thickness = (int) Math.floor(scaling);
+                int thickness = clipRound(scaling);
 
                 checkVerticalBorders(textFieldSize.width / 2, thickness, img);
 


### PR DESCRIPTION
This pull request contains a backport of commit [24117c6e](https://github.com/openjdk/jdk/commit/24117c6e9aa862bad839e93eff70810a75605ac5) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Rajat Mahajan on 3 Jul 2025 and was reviewed by Alexey Ivanov and Sergey Bylokhov.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8349188](https://bugs.openjdk.org/browse/JDK-8349188) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8349188](https://bugs.openjdk.org/browse/JDK-8349188): LineBorder does not scale correctly (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/134.diff">https://git.openjdk.org/jdk25u/pull/134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/134#issuecomment-3220438761)
</details>
