### PR TITLE
8366028: MethodType::fromMethodDescriptorString should not throw UnsupportedOperationException for invalid descriptors

### DIFF
--- a/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
+++ b/src/java.base/share/classes/sun/invoke/util/BytecodeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,8 +96,15 @@ public class BytecodeDescriptor {
             }
         } else if (c == '[') {
             Class<?> t = parseSig(str, i, end, loader);
-            if (t != null)
-                t = t.arrayType();
+            if (t != null) {
+                try {
+                    t = t.arrayType();
+                } catch (UnsupportedOperationException ex) {
+                    // Bad arrays, such as [V or more than 255 dims
+                    // We have a more informative IAE
+                    return null;
+                }
+            }
             return t;
         } else {
             return Wrapper.forBasicType(c).primitiveType();

--- a/test/jdk/java/lang/invoke/MethodTypeTest.java
+++ b/test/jdk/java/lang/invoke/MethodTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 
 /* @test
+ * @bug 8366028
  * @summary unit tests for java.lang.invoke.MethodType
  * @compile MethodTypeTest.java
  * @run testng/othervm test.java.lang.invoke.MethodTypeTest
@@ -35,6 +36,8 @@ import java.lang.reflect.Method;
 
 import java.util.*;
 import org.testng.*;
+
+import static org.testng.Assert.assertThrows;
 import static org.testng.AssertJUnit.*;
 import org.testng.annotations.*;
 
@@ -216,6 +219,24 @@ public class MethodTypeTest {
             prevPart = part;
         }
         return sb.toString().replace('.', '/');
+    }
+
+    @DataProvider(name = "badMethodDescriptorStrings")
+    public String[] badMethodDescriptorStrings() {
+        return new String[] {
+                "(I)",
+                "(V)V",
+                "([V)V",
+                "(" + "[".repeat(256) + "J)I",
+                "(java/lang/Object)V",
+                "()java/lang/Object",
+        };
+    }
+
+    // JDK-8366028
+    @Test(dataProvider = "badMethodDescriptorStrings", expectedExceptions = IllegalArgumentException.class)
+    public void testFromMethodDescriptorStringNegatives(String desc) {
+        MethodType.fromMethodDescriptorString(desc, null);
     }
 
     @Test


### PR DESCRIPTION
Please review this patch that fixes a bug with `MethodType::fromMethodDescriptorString` introduced in 22. Since this bug has not affected any LTS yet, I think it would be reasonable to fix this in 25 LTS releases before this behavior becomes an accidental dependency in LTS users.

Original PR: https://github.com/openjdk/jdk/pull/26909

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8366028](https://bugs.openjdk.org/browse/JDK-8366028) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366028](https://bugs.openjdk.org/browse/JDK-8366028): MethodType::fromMethodDescriptorString should not throw UnsupportedOperationException for invalid descriptors (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/139/head:pull/139` \
`$ git checkout pull/139`

Update a local copy of the PR: \
`$ git checkout pull/139` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 139`

View PR using the GUI difftool: \
`$ git pr show -t 139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/139.diff">https://git.openjdk.org/jdk25u/pull/139.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/139#issuecomment-3228737263)
</details>
