### PR TITLE
8362532: Test gc/g1/plab/* duplicate command-line options

### DIFF
--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABEvacuationFailure.java
@@ -99,7 +99,6 @@ public class TestPLABEvacuationFailure {
         // Set up test GC and PLAB options
         List<String> testOptions = new ArrayList<>();
         Collections.addAll(testOptions, COMMON_OPTIONS);
-        Collections.addAll(testOptions, Utils.getTestJavaOpts());
         Collections.addAll(testOptions,
                 "-XX:ParallelGCThreads=" + parGCThreads,
                 "-XX:ParallelGCBufferWastePct=" + wastePct,

--- a/test/hotspot/jtreg/gc/g1/plab/lib/PLABUtils.java
+++ b/test/hotspot/jtreg/gc/g1/plab/lib/PLABUtils.java
@@ -72,14 +72,12 @@ public class PLABUtils {
         if (options == null) {
             throw new IllegalArgumentException("Options cannot be null");
         }
-        List<String> executionOtions = new ArrayList<>(
-                Arrays.asList(Utils.getTestJavaOpts())
-        );
-        Collections.addAll(executionOtions, WB_DIAGNOSTIC_OPTIONS);
-        Collections.addAll(executionOtions, G1_PLAB_LOGGING_OPTIONS);
-        Collections.addAll(executionOtions, GC_TUNE_OPTIONS);
-        executionOtions.addAll(options);
-        return executionOtions;
+        List<String> executionOptions = new ArrayList<>();
+        Collections.addAll(executionOptions, WB_DIAGNOSTIC_OPTIONS);
+        Collections.addAll(executionOptions, G1_PLAB_LOGGING_OPTIONS);
+        Collections.addAll(executionOptions, GC_TUNE_OPTIONS);
+        executionOptions.addAll(options);
+        return executionOptions;
     }
 
     /**


### PR DESCRIPTION
Clean backport. Removed additional command line in tests.
 Tested in mach5 in all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362532](https://bugs.openjdk.org/browse/JDK-8362532) needs maintainer approval

### Issue
 * [JDK-8362532](https://bugs.openjdk.org/browse/JDK-8362532): Test gc/g1/plab/* duplicate command-line options (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/147/head:pull/147` \
`$ git checkout pull/147`

Update a local copy of the PR: \
`$ git checkout pull/147` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 147`

View PR using the GUI difftool: \
`$ git pr show -t 147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/147.diff">https://git.openjdk.org/jdk25u/pull/147.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/147#issuecomment-3241097201)
</details>
