### PR TITLE
Backport 44cff9d6abab5df086e89df16f8b63c48cd33c7b

### DIFF
--- a/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
+++ b/test/jdk/java/awt/Frame/BogusFocusableWindowState/BogusFocusableWindowState.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Window;
+
+/**
+ * @test
+ * @bug 8346952
+ * @summary Verifies no exception occurs when triggering updateCG()
+ * for an ownerless window.
+ * @key headful
+ */
+public final class BogusFocusableWindowState {
+
+    public static void main(String[] args) {
+        Window frame = new Window(null) {
+            @Override
+            public boolean getFocusableWindowState() {
+                removeNotify();
+                return true;
+            }
+        };
+        try {
+            frame.pack();
+            frame.setVisible(true);
+        } finally {
+            frame.dispose();
+        }
+    }
+}

--- a/test/jdk/java/awt/Frame/GetGraphicsStressTest/GetGraphicsStressTest.java
+++ b/test/jdk/java/awt/Frame/GetGraphicsStressTest/GetGraphicsStressTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * @test
- * @bug 8235638 8235739 8285094
+ * @bug 8235638 8235739 8285094 8346952
  * @key headful
  */
 public final class GetGraphicsStressTest {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [44cff9d6](https://github.com/openjdk/jdk/commit/44cff9d6abab5df086e89df16f8b63c48cd33c7b) and [f7352750](https://git.openjdk.org/jdk/commit/f73527502177a8f050272d6157ccbec3e9840bc8)  from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Anass Baya on 7 Jul 2025 and was reviewed by Sergey Bylokhov.

Thanks!