### PR TITLE
8366031: Mark com/sun/nio/sctp/SctpChannel/CloseDescriptors.java as intermittent

### DIFF
--- a/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
+++ b/test/jdk/com/sun/nio/sctp/SctpChannel/CloseDescriptors.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @bug 8238274
+ * @key intermittent
  * @summary Potential leak file descriptor for SCTP
  * @requires (os.family == "linux")
  * @library /test/lib


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [efb81daf](https://github.com/openjdk/jdk/commit/efb81dafaf6da334674e52dbb509208d7d872440) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 2 Sep 2025 and was reviewed by Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366031](https://bugs.openjdk.org/browse/JDK-8366031) needs maintainer approval

### Issue
 * [JDK-8366031](https://bugs.openjdk.org/browse/JDK-8366031): Mark com/sun/nio/sctp/SctpChannel/CloseDescriptors.java as intermittent (**Sub-task** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/153/head:pull/153` \
`$ git checkout pull/153`

Update a local copy of the PR: \
`$ git checkout pull/153` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 153`

View PR using the GUI difftool: \
`$ git pr show -t 153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/153.diff">https://git.openjdk.org/jdk25u/pull/153.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/153#issuecomment-3244075123)
</details>
