### PR TITLE
8366147: ZGC: ZPageAllocator::cleanup_failed_commit_single_partition may leak memory

### DIFF
--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -1087,7 +1087,8 @@ void ZPartition::free_memory_alloc_failed(ZMemoryAllocation* allocation) {
     freed += vmem.size();
     _cache.insert(vmem);
   }
-  assert(allocation->harvested() + allocation->committed_capacity() == freed, "must have freed all");
+  assert(allocation->harvested() + allocation->committed_capacity() == freed, "must have freed all"
+         " %zu + %zu == %zu", allocation->harvested(), allocation->committed_capacity(), freed);
 
   // Adjust capacity to reflect the failed capacity increase
   const size_t remaining = allocation->size() - freed;
@@ -1904,23 +1905,27 @@ void ZPageAllocator::cleanup_failed_commit_single_partition(ZSinglePartitionAllo
   ZMemoryAllocation* const allocation = single_partition_allocation->allocation();
 
   assert(allocation->commit_failed(), "Must have failed to commit");
+  assert(allocation->partial_vmems()->is_empty(), "Invariant for single partition commit failure");
 
-  const size_t committed = allocation->committed_capacity();
-  const ZVirtualMemory non_harvested_vmem = vmem.last_part(allocation->harvested());
-  const ZVirtualMemory committed_vmem = non_harvested_vmem.first_part(committed);
-  const ZVirtualMemory non_committed_vmem = non_harvested_vmem.last_part(committed);
+  // For a single partition we have unmapped the harvested memory before we
+  // started committing, and moved its physical memory association to the start
+  // of the vmem. As such, the partial_vmems is empty. All the harvested and
+  // partially successfully committed memory is mapped in the first part of vmem.
+  const size_t harvested_and_committed_capacity = allocation->harvested() + allocation->committed_capacity();
+  const ZVirtualMemory succeeded_vmem = vmem.first_part(harvested_and_committed_capacity);
+  const ZVirtualMemory failed_vmem = vmem.last_part(harvested_and_committed_capacity);
 
-  if (committed_vmem.size() > 0) {
+  if (succeeded_vmem.size() > 0) {
     // Register the committed and mapped memory. We insert the committed
     // memory into partial_vmems so that it will be inserted into the cache
     // in a subsequent step.
-    allocation->partial_vmems()->append(committed_vmem);
+    allocation->partial_vmems()->append(succeeded_vmem);
   }
 
   // Free the virtual and physical memory we fetched to use but failed to commit
   ZPartition& partition = allocation->partition();
-  partition.free_physical(non_committed_vmem);
-  partition.free_virtual(non_committed_vmem);
+  partition.free_physical(failed_vmem);
+  partition.free_virtual(failed_vmem);
 }
 
 void ZPageAllocator::cleanup_failed_commit_multi_partition(ZMultiPartitionAllocation* multi_partition_allocation, const ZVirtualMemory& vmem) {

--- a/test/hotspot/jtreg/gc/z/TestCommitFailure.java
+++ b/test/hotspot/jtreg/gc/z/TestCommitFailure.java
@@ -24,6 +24,14 @@
 package gc.z;
 
 /*
+ * @test id=Normal
+ * @requires vm.gc.Z & vm.debug
+ * @summary Test ZGC graceful failure when a commit fails
+ * @library / /test/lib
+ * @run driver gc.z.TestCommitFailure
+ */
+
+/*
  * @test id=ZFakeNUMA
  * @requires vm.gc.Z & vm.debug
  * @library / /test/lib


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [86d6a2e0](https://github.com/openjdk/jdk/commit/86d6a2e05eb52ea2c603a06bce838a56d5ae507b) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Axel Boldt-Christmas on 29 Aug 2025 and was reviewed by Stefan Karlsson, Stefan Johansson and Joel Sikström.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8366147](https://bugs.openjdk.org/browse/JDK-8366147) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8366147](https://bugs.openjdk.org/browse/JDK-8366147): ZGC: ZPageAllocator::cleanup_failed_commit_single_partition may leak memory (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/159/head:pull/159` \
`$ git checkout pull/159`

Update a local copy of the PR: \
`$ git checkout pull/159` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 159`

View PR using the GUI difftool: \
`$ git pr show -t 159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/159.diff">https://git.openjdk.org/jdk25u/pull/159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/159#issuecomment-3247854881)
</details>
