### PR TITLE
8358685: [TEST] AOTLoggingTag.java failed with missing log message

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTLoggingTag.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/AOTLoggingTag.java
@@ -34,7 +34,6 @@
  * @run driver AOTLoggingTag
  */
 
-import java.io.File;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.helpers.ClassFileInstaller;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -59,7 +58,7 @@ public class AOTLoggingTag {
             "-cp", appJar, helloClass);
 
         out = CDSTestUtils.executeAndLog(pb, "train");
-        out.shouldContain("[info][aot] Writing binary AOTConfiguration file:");
+        out.shouldContain("[aot] Writing binary AOTConfiguration file:");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -71,7 +70,7 @@ public class AOTLoggingTag {
             "-Xlog:aot",
             "-cp", appJar);
         out = CDSTestUtils.executeAndLog(pb, "asm");
-        out.shouldContain("[info][aot] Opened AOT configuration file hello.aotconfig");
+        out.shouldContain("[aot] Opened AOT configuration file hello.aotconfig");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -81,7 +80,7 @@ public class AOTLoggingTag {
             "-Xlog:aot",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
-        out.shouldContain("[info][aot] Opened AOT cache hello.aot");
+        out.shouldContain("[aot] Opened AOT cache hello.aot");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -92,7 +91,7 @@ public class AOTLoggingTag {
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
         out.shouldNotContain("No tag set matches selection: aot+heap");
-        out.shouldContain("[info][aot,heap] resolve subgraph java.lang.Integer$IntegerCache");
+        out.shouldContain("[aot,heap] resolve subgraph java.lang.Integer$IntegerCache");
         out.shouldHaveExitValue(0);
 
         //----------------------------------------------------------------------
@@ -102,7 +101,7 @@ public class AOTLoggingTag {
             "-XX:AOTMode=on",
             "-cp", appJar, helloClass);
         out = CDSTestUtils.executeAndLog(pb, "prod");
-        out.shouldContain("[error][aot] An error has occurred while processing the AOT cache. Run with -Xlog:aot for details.");
+        out.shouldContain("[aot] An error has occurred while processing the AOT cache. Run with -Xlog:aot for details.");
         out.shouldNotHaveExitValue(0);
     }
 


### PR DESCRIPTION
8358685: [TEST] AOTLoggingTag.java failed with missing log message

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8358685](https://bugs.openjdk.org/browse/JDK-8358685) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8358685](https://bugs.openjdk.org/browse/JDK-8358685): [TEST] AOTLoggingTag.java failed with missing log message (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/160/head:pull/160` \
`$ git checkout pull/160`

Update a local copy of the PR: \
`$ git checkout pull/160` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 160`

View PR using the GUI difftool: \
`$ git pr show -t 160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/160.diff">https://git.openjdk.org/jdk25u/pull/160.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/160#issuecomment-3248031376)
</details>
