### PR TITLE
8361215: Add AOT test case: verification constraint classes are excluded

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -417,6 +417,7 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/aotClassLinking \
  -runtime/cds/appcds/aotCode \
  -runtime/cds/appcds/aotFlags \
+ -runtime/cds/appcds/aotProfile \
  -runtime/cds/appcds/applications \
  -runtime/cds/appcds/cacheObject \
  -runtime/cds/appcds/complexURI \
@@ -511,14 +512,17 @@ hotspot_cds_epsilongc = \
   runtime/cds/appcds/jigsaw \
   runtime/cds/appcds/loaderConstraints
 
-# Run CDS tests with -XX:+AOTClassLinking. This should include most CDS tests, except for
+# Run "old" CDS tests with -XX:+AOTClassLinking. This should include most CDS tests, except for
 # those that rely on redefining classes that are already archived.
+# Note that appcds/aotXXX directories are excluded -- those tests already specifically
+# test AOT class linking, so there's no need to run them again with -XX:+AOTClassLinking.
 hotspot_aot_classlinking = \
   runtime/cds \
  -runtime/cds/appcds/aotCache \
  -runtime/cds/appcds/aotClassLinking \
  -runtime/cds/appcds/aotCode \
  -runtime/cds/appcds/aotFlags \
+ -runtime/cds/appcds/aotProfile \
  -runtime/cds/appcds/BadBSM.java \
  -runtime/cds/appcds/cacheObject/ArchivedIntegerCacheTest.java \
  -runtime/cds/appcds/cacheObject/ArchivedModuleCompareTest.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ExcludedClasses.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/aotCache/ExcludedClasses.java
@@ -36,6 +36,8 @@
  *                 TestApp$Foo
  *                 TestApp$Foo$Bar
  *                 TestApp$Foo$ShouldBeExcluded
+ *                 TestApp$Foo$ShouldBeExcludedChild
+ *                 TestApp$Foo$Taz
  *                 TestApp$MyInvocationHandler
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar cust.jar
  *                 CustyWithLoop
@@ -63,7 +65,7 @@ public class ExcludedClasses {
 
     public static void main(String[] args) throws Exception {
         Tester tester = new Tester();
-        tester.runAOTWorkflow();
+        tester.runAOTWorkflow("AOT", "--two-step-training");
     }
 
     static class Tester extends CDSAppTester {
@@ -79,7 +81,11 @@ public class ExcludedClasses {
         @Override
         public String[] vmArgs(RunMode runMode) {
             return new String[] {
-                "-Xlog:cds+resolve=trace",
+                "-Xlog:aot=debug",
+                "-Xlog:aot+class=debug",
+                "-Xlog:aot+resolve=trace",
+                "-Xlog:aot+verification=trace",
+                "-Xlog:class+load",
             };
         }
 
@@ -92,8 +98,16 @@ public class ExcludedClasses {
 
         @Override
         public void checkExecution(OutputAnalyzer out, RunMode runMode) {
-            if (isDumping(runMode)) {
-                out.shouldNotMatch("cds,resolve.*archived field.*TestApp.Foo => TestApp.Foo.ShouldBeExcluded.f:I");
+            if (runMode == RunMode.TRAINING) {
+                out.shouldMatch("aot,resolve.*reverted field.*TestApp.Foo => TestApp.Foo.ShouldBeExcluded.f:I");
+            } else if (runMode == RunMode.ASSEMBLY) {
+                out.shouldNotMatch("aot,resolve.*archived field.*TestApp.Foo => TestApp.Foo.ShouldBeExcluded.f:I");
+                out.shouldMatch("aot,resolve.*archived method.*TestApp.Foo java/lang/Integer.intValue:[(][)]I => java/lang/Integer");
+            } else if (runMode == RunMode.PRODUCTION) {
+                out.shouldContain("check_verification_constraint: TestApp$Foo$Taz: TestApp$Foo$ShouldBeExcludedChild must be subclass of TestApp$Foo$ShouldBeExcluded");
+                out.shouldContain("jdk.jfr.Event source: jrt:/jdk.jfr");
+                out.shouldMatch("TestApp[$]Foo[$]ShouldBeExcluded source: .*/app.jar");
+                out.shouldMatch("TestApp[$]Foo[$]ShouldBeExcludedChild source: .*/app.jar");
             }
         }
     }
@@ -104,8 +118,8 @@ class TestApp {
     static volatile Object custArrayInstance;
 
     public static void main(String args[]) throws Exception {
-        // In new workflow, classes from custom loaders are passed from the preimage
-        // to the final image. See ClassPrelinker::record_unregistered_klasses().
+        // In AOT workflow, classes from custom loaders are passed from the preimage
+        // to the final image. See FinalImageRecipes::record_all_classes().
         custInstance = initFromCustomLoader();
         custArrayInstance = Array.newInstance(custInstance.getClass(), 0);
         System.out.println(custArrayInstance);
@@ -159,6 +173,7 @@ class TestApp {
                 lambdaHotSpot();
                 s.hotSpot2();
                 b.hotSpot3();
+                Taz.hotSpot4();
 
                 // In JDK mainline, generated proxy classes are excluded from the AOT cache.
                 // In Leyden/premain, generated proxy classes included. The following code should
@@ -167,7 +182,7 @@ class TestApp {
                 counter += i.intValue();
 
                 if (custInstance != null) {
-                    // Classes loaded by custom loaders are included included in the AOT cache
+                    // Classes loaded by custom loaders are included in the AOT cache
                     // but their array classes are excluded.
                     counter += custInstance.equals(null) ? 1 : 2;
                 }
@@ -218,6 +233,16 @@ class TestApp {
                     f();
                 }
             }
+            int func() {
+                return 1;
+            }
+        }
+
+        static class ShouldBeExcludedChild extends ShouldBeExcluded {
+            @Override
+            int func() {
+                return 2;
+            }
         }
 
         static class Bar {
@@ -227,6 +252,29 @@ class TestApp {
             }
 
             void hotSpot3() {
+                long start = System.currentTimeMillis();
+                while (System.currentTimeMillis() - start < 20) {
+                    for (int i = 0; i < 50000; i++) {
+                        counter += i;
+                    }
+                    f();
+                }
+            }
+        }
+
+        static class Taz {
+            static ShouldBeExcluded m() {
+                // When verifying this method, we need to check the constraint that
+                // ShouldBeExcluded must be a supertype of ShouldBeExcludedChild. This information
+                // is checked by SystemDictionaryShared::check_verification_constraints() when the Taz
+                // class is linked during the production run.
+                //
+                // Because ShouldBeExcluded is excluded from the AOT archive, it must be loaded
+                // dynamically from app.jar inside SystemDictionaryShared::check_verification_constraints().
+                // This must happen after the app class loader has been fully restored from the AOT cache.
+                return new ShouldBeExcludedChild();
+            }
+            static void hotSpot4() {
                 long start = System.currentTimeMillis();
                 while (System.currentTimeMillis() - start < 20) {
                     for (int i = 0; i < 50000; i++) {

--- a/test/lib/jdk/test/lib/cds/CDSAppTester.java
+++ b/test/lib/jdk/test/lib/cds/CDSAppTester.java
@@ -262,7 +262,7 @@ abstract public class CDSAppTester {
                                                              "class+load=debug",
                                                              "aot=debug",
                                                              "cds=debug",
-                                                             "cds+class=debug"));
+                                                             "aot+class=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotConfigurationFile, aotConfigurationFileLog);
@@ -275,8 +275,9 @@ abstract public class CDSAppTester {
                                                    "-XX:AOTCacheOutput=" + aotCacheFile,
                                                    logToFile(aotCacheFileLog,
                                                              "class+load=debug",
-                                                             "cds=debug",
-                                                             "cds+class=debug"));
+                                                             "aot=debug",
+                                                             "aot+class=debug",
+                                                             "cds=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         OutputAnalyzer out =  executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
@@ -310,7 +311,7 @@ abstract public class CDSAppTester {
                                                              "cds=debug",
                                                              "cds+class=debug",
                                                              "aot+heap=warning",
-                                                             "cds+resolve=debug"));
+                                                             "aot+resolve=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, staticArchiveFile, staticArchiveFileLog);
@@ -326,11 +327,11 @@ abstract public class CDSAppTester {
                                                    "-XX:AOTConfiguration=" + aotConfigurationFile,
                                                    "-XX:AOTCache=" + aotCacheFile,
                                                    logToFile(aotCacheFileLog,
-                                                             "aot=debug",
                                                              "cds=debug",
-                                                             "cds+class=debug",
+                                                             "aot=debug",
+                                                             "aot+class=debug",
                                                              "aot+heap=warning",
-                                                             "cds+resolve=debug"));
+                                                             "aot+resolve=debug"));
         cmdLine = addCommonVMArgs(runMode, cmdLine);
         cmdLine = StringArrayUtils.concat(cmdLine, appCommandLine(runMode));
         return executeAndCheck(cmdLine, runMode, aotCacheFile, aotCacheFileLog);
@@ -377,7 +378,7 @@ abstract public class CDSAppTester {
                                                       "aot=debug",
                                                       "cds=debug",
                                                       "cds+class=debug",
-                                                      "cds+resolve=debug",
+                                                      "aot+resolve=debug",
                                                       "class+load=debug"));
           cmdLine = addCommonVMArgs(runMode, cmdLine);
         }


### PR DESCRIPTION
8361215: Add AOT test case: verification constraint classes are excluded

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361215](https://bugs.openjdk.org/browse/JDK-8361215) needs maintainer approval

### Issue
 * [JDK-8361215](https://bugs.openjdk.org/browse/JDK-8361215): Add AOT test case: verification constraint classes are excluded (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/161/head:pull/161` \
`$ git checkout pull/161`

Update a local copy of the PR: \
`$ git checkout pull/161` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 161`

View PR using the GUI difftool: \
`$ git pr show -t 161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/161.diff">https://git.openjdk.org/jdk25u/pull/161.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/161#issuecomment-3248111247)
</details>
