### PR TITLE
8366694: Test JdbStopInNotificationThreadTest.java timed out after 60 second

### DIFF
--- a/test/jdk/com/sun/jdi/JdbStopInNotificationThreadTest.java
+++ b/test/jdk/com/sun/jdi/JdbStopInNotificationThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,9 +113,11 @@ public class JdbStopInNotificationThreadTest extends JdbTest {
     private static final String DEBUGGEE_CLASS = JdbStopInNotificationThreadTestTarg.class.getName();
     private static final String PATTERN1_TEMPLATE = "^Breakpoint hit: \"thread=Notification Thread\", " +
             "JdbStopInNotificationThreadTestTarg\\$1\\.handleNotification\\(\\), line=%LINE_NUMBER.*\\R%LINE_NUMBER\\s+System\\.out\\.println\\(\"Memory usage low!!!\"\\);.*";
+    private static final String[] DEBUGGEE_OPTIONS = {"-Xmx64M"};
 
     private JdbStopInNotificationThreadTest() {
-        super(DEBUGGEE_CLASS);
+        super(new LaunchOptions(DEBUGGEE_CLASS)
+                .addDebuggeeOptions(DEBUGGEE_OPTIONS));
     }
 
     public static void main(String argv[]) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ed62bda2](https://github.com/openjdk/jdk/commit/ed62bda2e0c51a67baae1fc28e41c9cd878db5f4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 4 Sep 2025 and was reviewed by Chris Plummer, Albert Mingkun Yang and Leonid Mesnik.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8366694](https://bugs.openjdk.org/browse/JDK-8366694) needs maintainer approval

### Issue
 * [JDK-8366694](https://bugs.openjdk.org/browse/JDK-8366694): Test JdbStopInNotificationThreadTest.java timed out after 60 second (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/165/head:pull/165` \
`$ git checkout pull/165`

Update a local copy of the PR: \
`$ git checkout pull/165` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 165`

View PR using the GUI difftool: \
`$ git pr show -t 165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/165.diff">https://git.openjdk.org/jdk25u/pull/165.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/165#issuecomment-3251721966)
</details>
