### PR TITLE
Backport 57553ca1dbc63e329116bc11764816a4c5ccb297

### DIFF
--- a/test/jdk/javax/swing/SwingUtilities/bug4967768.java
+++ b/test/jdk/javax/swing/SwingUtilities/bug4967768.java
@@ -37,13 +37,19 @@ import javax.swing.JPanel;
 
 public class bug4967768 {
     private static final String INSTRUCTIONS = """
-            When the test starts you'll see a button "Oops"
-            with the "p" letter underlined at the bottom
-            of the instruction frame.
+            When the test starts you'll see a button "Oops".
+
+            For Windows and GTK Look and Feel, you will need to
+            press the ALT key to make the mnemonic visible.
+            Once the ALT key is pressed, the letter "p" will be
+            underlined at the bottom of the instruction frame.
 
             Ensure the underline cuts through the descender
             of letter "p", i.e. the underline is painted
             not below the letter but below the baseline.
+
+            Press Pass if you see the expected behaviour else
+            press Fail.
             """;
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
- PR Changes
For Windows and GTK L&F, mnemonic is visible when ALT key is pressed.
Test instruction updated to reflect the desired behaviour.

- Testing
[JTREG Testing] (1 manual test ) - The results after running the test locally using jtreg are as expected.
runner starting test: javax/swing/SwingUtilities/bug4967768.java
runner finished test: javax/swing/SwingUtilities/bug4967768.java
Passed. Execution successful
Test results: passed: 1


- Conflicts
No conflicts. Clean backport.

- Are higher backports completed(25u,21u,17u,11u,8u etc) ?
Applicable to 25u via this MR and the others are being worked upon.

- Does it contain multiple changesets ?
No