### PR TITLE
Backport ea7e943874288e1cbea10a6bd82d6c7f2a1c9ae0

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SettingsManager.java
@@ -194,7 +194,7 @@ final class SettingsManager {
             String key = entry.getKey();
             String value = entry.getValue();
             int index = key.indexOf("#");
-            if (index > 1 && index < key.length() - 2) {
+            if (index > 0 && index < key.length() - 1) {
                 String eventName = key.substring(0, index);
                 eventName = Utils.upgradeLegacyJDKEvent(eventName);
                 InternalSetting s = internals.get(eventName);

--- a/test/jdk/jdk/jfr/api/flightrecorder/TestSettingsControl.java
+++ b/test/jdk/jdk/jfr/api/flightrecorder/TestSettingsControl.java
@@ -28,6 +28,7 @@ import static jdk.test.lib.Asserts.assertTrue;
 import java.util.Set;
 
 import jdk.jfr.Event;
+import jdk.jfr.Name;
 import jdk.jfr.Recording;
 import jdk.jfr.SettingControl;
 import jdk.jfr.SettingDefinition;
@@ -42,7 +43,7 @@ import jdk.jfr.SettingDefinition;
 public class TestSettingsControl {
     static class MySettingsControl extends SettingControl {
 
-        public static boolean setWasCalled;
+        public static boolean myvalueSet;
 
         private String value = "default";
 
@@ -57,7 +58,9 @@ public class TestSettingsControl {
 
         @Override
         public void setValue(String value) {
-            setWasCalled = true;
+            if ("myvalue".equals(value)) {
+                myvalueSet = true;
+            }
             this.value = value;
         }
 
@@ -67,9 +70,10 @@ public class TestSettingsControl {
         }
 
     }
-
+    @Name("M")
     static class MyCustomSettingEvent extends Event {
         @SettingDefinition
+        @Name("m")
         boolean mySetting(MySettingsControl msc) {
             return true;
         }
@@ -77,13 +81,13 @@ public class TestSettingsControl {
 
     public static void main(String[] args) throws Throwable {
         Recording r = new Recording();
-        r.enable(MyCustomSettingEvent.class).with("mySetting", "myvalue");
+        r.enable("M").with("m", "myvalue");
         r.start();
         MyCustomSettingEvent e = new MyCustomSettingEvent();
         e.commit();
         r.stop();
         r.close();
-        assertTrue(MySettingsControl.setWasCalled, "SettingControl.setValue was not called");
+        assertTrue(MySettingsControl.myvalueSet, "SettingControl.setValue(\"myvalue\") was not called");
     }
 }
 


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8364257

This fixes a bug where a single letter name jfr event couldn't be configured. On tip for about one month. The test `test/jdk/jdk/jfr/api/flightrecorder/TestSettingsControl.java` passed locally. Other tests are running. Relatively low risk.