### PR TITLE
Backport 0aee7bf24d7f2578d3867bcfa25646cb0bd06d9a

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3824,13 +3824,18 @@ opclass immIorL(immI, immL);
 pipeline %{
 
 attributes %{
-  // RISC-V instructions are of fixed length
-  fixed_size_instructions;           // Fixed size instructions TODO does
-  max_instructions_per_bundle = 2;   // Generic RISC-V 1, Sifive Series 7 2
-  // RISC-V instructions come in 32-bit word units
-  instruction_unit_size = 4;         // An instruction is 4 bytes long
-  instruction_fetch_unit_size = 64;  // The processor fetches one line
-  instruction_fetch_units = 1;       // of 64 bytes
+  // RISC-V instructions are of length 2 or 4 bytes.
+  variable_size_instructions;
+  instruction_unit_size = 2;
+
+  // Up to 4 instructions per bundle
+  max_instructions_per_bundle = 4;
+
+  // The RISC-V processor fetches 64 bytes...
+  instruction_fetch_unit_size = 64;
+
+  // ...in one line.
+  instruction_fetch_units = 1;
 
   // List of nop instructions
   nops( MachNop );


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0aee7bf2](https://github.com/openjdk/jdk/commit/0aee7bf24d7f2578d3867bcfa25646cb0bd06d9a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 9 Sep 2025 and was reviewed by Fei Yang, Feilong Jiang and Hamlin Li.

Thanks!