### PR TITLE
Backport ac9e51023fc34a82b795950a109af2397826adaa

### DIFF
--- a/test/hotspot/jtreg/gtest/GTestWrapper.java
+++ b/test/hotspot/jtreg/gtest/GTestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,7 @@ public class GTestWrapper {
         command.add(execPath.toAbsolutePath().toString());
         command.add("-jdk");
         command.add(Utils.TEST_JDK);
+        command.add("-Xmx200m");
         command.add("--gtest_output=xml:" + resultFile);
         command.add("--gtest_catch_exceptions=0");
         for (String a : args) {


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8320836.

This patch limits the gtest max heap size. In the original [JBS](https://bugs.openjdk.org/browse/JDK-8320836), there was already a customer report saying CI pipeline gtest failed due to large heap. Backporting this patch can benefit non tip customers.