### PR TITLE
Backport 2202156acc78d7d9ec128f8df5c09fcdff83697c

### DIFF
--- a/src/hotspot/share/nmt/mallocHeader.inline.hpp
+++ b/src/hotspot/share/nmt/mallocHeader.inline.hpp
@@ -104,7 +104,7 @@ inline OutTypeParam MallocHeader::resolve_checked_impl(InTypeParam memblock) {
   OutTypeParam header_pointer = (OutTypeParam)memblock - 1;
   if (!header_pointer->check_block_integrity(msg, sizeof(msg), &corruption)) {
     header_pointer->print_block_on_error(tty, corruption != nullptr ? corruption : (address)header_pointer);
-    fatal("NMT corruption: Block at " PTR_FORMAT ": %s", p2i(memblock), msg);
+    fatal("NMT has detected a memory corruption bug. Block at " PTR_FORMAT ": %s", p2i(memblock), msg);
   }
   return header_pointer;
 }

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -35,7 +35,7 @@
 
 // This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
 // come, just use this one.
-#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT corruption"
+#define COMMON_NMT_HEAP_CORRUPTION_MESSAGE_PREFIX "NMT has detected a memory corruption bug."
 
 #define DEFINE_TEST(test_function, expected_assertion_message)                            \
   TEST_VM_FATAL_ERROR_MSG(NMT, test_function, ".*" expected_assertion_message ".*") {     \


### PR DESCRIPTION
A clean backport of https://bugs.openjdk.org/browse/JDK-8364198.

This patch improves the error message, quite straight forward as the error message itself - NMT detected a bug somewhere else, but not in itself. Error message change. Low risks.