### PR TITLE
8366893: java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java timed out on macos-aarch64

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
@@ -53,8 +53,8 @@ public class GetStackTraceALotWhenBlocking {
 
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX() && Platform.isX64()) {
-            // reduced iterations on macosx-x64
+        if (Platform.isOSX()) {
+            // reduced iterations on macosx
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -56,8 +56,8 @@ public class GetStackTraceALotWhenPinned {
 
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX() && Platform.isX64()) {
-            // reduced iterations on macosx-x64
+        if (Platform.isOSX()) {
+            // reduced iterations on macosx
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;

--- a/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/ParkALot.java
@@ -49,8 +49,8 @@ public class ParkALot {
     public static void main(String[] args) throws Exception {
         int iterations;
         int value = Integer.parseInt(args[0]);
-        if (Platform.isOSX() && Platform.isX64()) {
-            // reduced iterations on macosx-x64
+        if (Platform.isOSX()) {
+            // reduced iterations on macosx
             iterations = Math.max(value / 4, 1);
         } else {
             iterations = value;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 0dad3f1a from the openjdk/jdk repository.

The commit being backported was authored by Aleksey Shipilev on 5 Sep 2025 and was reviewed by Alan Bateman and Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366893](https://bugs.openjdk.org/browse/JDK-8366893) needs maintainer approval

### Issue
 * [JDK-8366893](https://bugs.openjdk.org/browse/JDK-8366893): java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java timed out on macos-aarch64 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/184/head:pull/184` \
`$ git checkout pull/184`

Update a local copy of the PR: \
`$ git checkout pull/184` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 184`

View PR using the GUI difftool: \
`$ git pr show -t 184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/184.diff">https://git.openjdk.org/jdk25u/pull/184.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/184#issuecomment-3280101895)
</details>
