### PR TITLE
8367066: RISC-V: refine register selection in MacroAssembler:: decode_klass_not_null

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -8932,7 +8932,7 @@ instruct encodeKlass_not_null(iRegNNoSp dst, iRegP src) %{
 instruct decodeKlass_not_null(iRegPNoSp dst, iRegN src, iRegPNoSp tmp) %{
   match(Set dst (DecodeNKlass src));
 
-  effect(TEMP tmp);
+  effect(TEMP_DEF dst, TEMP tmp);
 
   ins_cost(ALU_COST);
   format %{ "decode_klass_not_null  $dst, $src\t#@decodeKlass_not_null" %}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [0b3a3030](https://github.com/openjdk/jdk/commit/0b3a303053d0eb5a98ed3d9df42c659db148b470) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Hamlin Li on 11 Sep 2025 and was reviewed by Fei Yang and Feilong Jiang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367066](https://bugs.openjdk.org/browse/JDK-8367066) needs maintainer approval

### Issue
 * [JDK-8367066](https://bugs.openjdk.org/browse/JDK-8367066): RISC-V: refine register selection in MacroAssembler:: decode_klass_not_null (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/185/head:pull/185` \
`$ git checkout pull/185`

Update a local copy of the PR: \
`$ git checkout pull/185` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 185`

View PR using the GUI difftool: \
`$ git pr show -t 185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/185.diff">https://git.openjdk.org/jdk25u/pull/185.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/185#issuecomment-3283400019)
</details>
