### PR TITLE
8365700: Jar --validate without any --file option leaves around a temporary file /tmp/tmpJar<number>.jar

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -420,7 +420,8 @@ public class Main {
                 if (fname != null) {
                     file = new File(fname);
                 } else {
-                    file = createTemporaryFile("tmpJar", ".jar");
+                    tmpFile = createTemporaryFile("tmpJar", ".jar");
+                    file = tmpFile;
                     try (InputStream in = new FileInputStream(FileDescriptor.in);
                          OutputStream os = Files.newOutputStream(file.toPath())) {
                         in.transferTo(os);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365700](https://bugs.openjdk.org/browse/JDK-8365700) needs maintainer approval

### Issue
 * [JDK-8365700](https://bugs.openjdk.org/browse/JDK-8365700): Jar --validate without any --file option leaves around a temporary file /tmp/tmpJar&lt;number&gt;.jar (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/189/head:pull/189` \
`$ git checkout pull/189`

Update a local copy of the PR: \
`$ git checkout pull/189` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 189`

View PR using the GUI difftool: \
`$ git pr show -t 189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/189.diff">https://git.openjdk.org/jdk25u/pull/189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/189#issuecomment-3284785334)
</details>
