### PR TITLE
8365442: [asan] runtime/ErrorHandling/CreateCoredumpOnCrash.java fails

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/CreateCoredumpOnCrash.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/CreateCoredumpOnCrash.java
@@ -30,6 +30,7 @@
  *          jdk.internal.jvmstat/sun.jvmstat.monitor
  * @run driver CreateCoredumpOnCrash
  * @requires vm.flagless
+ * @requires !vm.asan
  */
 
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8365442](https://bugs.openjdk.org/browse/JDK-8365442) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8365442](https://bugs.openjdk.org/browse/JDK-8365442): [asan] runtime/ErrorHandling/CreateCoredumpOnCrash.java fails (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/191/head:pull/191` \
`$ git checkout pull/191`

Update a local copy of the PR: \
`$ git checkout pull/191` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 191`

View PR using the GUI difftool: \
`$ git pr show -t 191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/191.diff">https://git.openjdk.org/jdk25u/pull/191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/191#issuecomment-3284954829)
</details>
