### PR TITLE
8367131: Test com/sun/jdi/ThreadMemoryLeakTest.java fails on 32 bits

### DIFF
--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -28,7 +28,7 @@
  *
  * @comment Don't allow -Xcomp or -Xint as they impact memory useage and number of iterations.
  *          Require compressed oops because not doing so increases memory usage.
- * @requires (vm.compMode == "Xmixed") & vm.opt.final.UseCompressedOops
+ * @requires (vm.compMode == "Xmixed") & (vm.bits == 32 | vm.opt.final.UseCompressedOops)
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g ThreadMemoryLeakTest.java
  * @comment run with -Xmx7m so any leak will quickly produce OOME


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [fdc11a15](https://github.com/openjdk/jdk/commit/fdc11a1569248c9b671b66d547b4616aeb953ecf) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Sergey Bylokhov on 10 Sep 2025 and was reviewed by Leonid Mesnik, Chris Plummer and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8367131](https://bugs.openjdk.org/browse/JDK-8367131) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367131](https://bugs.openjdk.org/browse/JDK-8367131): Test com/sun/jdi/ThreadMemoryLeakTest.java fails on 32 bits (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/194/head:pull/194` \
`$ git checkout pull/194`

Update a local copy of the PR: \
`$ git checkout pull/194` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 194`

View PR using the GUI difftool: \
`$ git pr show -t 194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/194.diff">https://git.openjdk.org/jdk25u/pull/194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/194#issuecomment-3293709809)
</details>
