### PR TITLE
8364296: Set IntelJccErratumMitigation flag ergonomically

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1069,6 +1069,7 @@ void VM_Version::get_processor_features() {
 
   if (FLAG_IS_DEFAULT(IntelJccErratumMitigation)) {
     _has_intel_jcc_erratum = compute_has_intel_jcc_erratum();
+    FLAG_SET_ERGO(IntelJccErratumMitigation, _has_intel_jcc_erratum);
   } else {
     _has_intel_jcc_erratum = IntelJccErratumMitigation;
   }


### PR DESCRIPTION
A clean backport for https://bugs.openjdk.org/browse/JDK-8337679

Add visibility of flag IntelJccErratumMitigation. In tip for around 1 month.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8364296](https://bugs.openjdk.org/browse/JDK-8364296) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364296](https://bugs.openjdk.org/browse/JDK-8364296): Set IntelJccErratumMitigation flag ergonomically (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/195/head:pull/195` \
`$ git checkout pull/195`

Update a local copy of the PR: \
`$ git checkout pull/195` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 195`

View PR using the GUI difftool: \
`$ git pr show -t 195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/195.diff">https://git.openjdk.org/jdk25u/pull/195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/195#issuecomment-3286651610)
</details>
