### PR TITLE
8367378: GenShen: Missing timing stats when old mark buffers are flushed during final update refs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -1198,6 +1198,7 @@ void ShenandoahConcurrentGC::op_final_update_refs() {
     // We are not concerned about skipping this step in abbreviated cycles because regions
     // with no live objects cannot have been written to and so cannot have entries in the SATB
     // buffers.
+    ShenandoahGCPhase phase(ShenandoahPhaseTimings::final_update_refs_transfer_satb);
     heap->old_generation()->transfer_pointers_from_satb();
 
     // Aging_cycle is only relevant during evacuation cycle for individual objects and during final mark for

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -126,6 +126,7 @@ class outputStream;
   f(final_update_refs,                              "Pause Final Update Refs (N)")     \
   f(final_update_refs_verify,                       "  Verify")                        \
   f(final_update_refs_update_region_states,         "  Update Region States")          \
+  f(final_update_refs_transfer_satb,                "  Transfer Old From SATB")        \
   f(final_update_refs_trash_cset,                   "  Trash Collection Set")          \
   f(final_update_refs_rebuild_freeset,              "  Rebuild Free Set")              \
   f(final_update_refs_propagate_gc_state,           "  Propagate GC State")            \


### PR DESCRIPTION
Clean backport. Only touches Shenandoah and is a trivial change at that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367378](https://bugs.openjdk.org/browse/JDK-8367378) needs maintainer approval

### Issue
 * [JDK-8367378](https://bugs.openjdk.org/browse/JDK-8367378): GenShen: Missing timing stats when old mark buffers are flushed during final update refs (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/196/head:pull/196` \
`$ git checkout pull/196`

Update a local copy of the PR: \
`$ git checkout pull/196` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 196`

View PR using the GUI difftool: \
`$ git pr show -t 196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/196.diff">https://git.openjdk.org/jdk25u/pull/196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/196#issuecomment-3286787206)
</details>
