### PR TITLE
8367098: RISC-V: sync CPU features with related JVM flags for dependant ones

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -86,25 +86,27 @@ class VM_Version : public Abstract_VM_Version {
     }                                    \
   }                                      \
 
-  #define UPDATE_DEFAULT_DEP(flag, dep)    \
-  void update_flag() {                     \
-      assert(enabled(), "Must be.");       \
-      /* dep must be declared before */    \
-      assert((uintptr_t)(this) >           \
-             (uintptr_t)(&dep), "Invalid");\
-      if (FLAG_IS_DEFAULT(flag)) {         \
-        if (dep.enabled()) {               \
-          FLAG_SET_DEFAULT(flag, true);    \
-        } else {                           \
-          FLAG_SET_DEFAULT(flag, false);   \
-        }                                  \
-      } else {                             \
-        /* Sync CPU features with flags */ \
-        if (!flag) {                       \
-          disable_feature();               \
-        }                                  \
-      }                                    \
-  }                                        \
+  #define UPDATE_DEFAULT_DEP(flag, dep)      \
+  void update_flag() {                       \
+      assert(enabled(), "Must be.");         \
+      /* dep must be declared before */      \
+      assert((uintptr_t)(this) >             \
+             (uintptr_t)(&dep), "Invalid");  \
+      if (FLAG_IS_DEFAULT(flag)) {           \
+        if (dep.enabled()) {                 \
+          FLAG_SET_DEFAULT(flag, true);      \
+        } else {                             \
+          FLAG_SET_DEFAULT(flag, false);     \
+          /* Sync CPU features with flags */ \
+          disable_feature();                 \
+        }                                    \
+      } else {                               \
+        /* Sync CPU features with flags */   \
+        if (!flag) {                         \
+          disable_feature();                 \
+        }                                    \
+      }                                      \
+  }                                          \
 
   #define NO_UPDATE_DEFAULT                \
   void update_flag() {}                    \


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [f51e442b](https://github.com/openjdk/jdk/commit/f51e442b0e26d0e9ebb6ec0da9584ba4f548322c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Hamlin Li on 9 Sep 2025 and was reviewed by Fei Yang.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367098](https://bugs.openjdk.org/browse/JDK-8367098) needs maintainer approval

### Issue
 * [JDK-8367098](https://bugs.openjdk.org/browse/JDK-8367098): RISC-V: sync CPU features with related JVM flags for dependant ones (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/199/head:pull/199` \
`$ git checkout pull/199`

Update a local copy of the PR: \
`$ git checkout pull/199` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 199`

View PR using the GUI difftool: \
`$ git pr show -t 199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/199.diff">https://git.openjdk.org/jdk25u/pull/199.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/199#issuecomment-3290173995)
</details>
