### PR TITLE
Backport 90e81c2bee86f404250fb9b833d43b18190b5272

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -191,6 +191,9 @@ void RiscvHwprobe::add_features_from_query_result() {
     VM_Version::ext_Zbs.enable_feature();
   }
 #ifndef PRODUCT
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZICBOZ)) {
+    VM_Version::ext_Zicboz.enable_feature();
+  }
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZBKB)) {
     VM_Version::ext_Zbkb.enable_feature();
   }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [90e81c2b](https://github.com/openjdk/jdk/commit/90e81c2bee86f404250fb9b833d43b18190b5272) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Dingli Zhang on 16 Sep 2025 and was reviewed by Fei Yang and Feilong Jiang.

Thanks!