### PR TITLE
8364352: Some tests fail when using a limited number of pregenerated .jsa CDS archives

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -80,6 +80,7 @@ requires.properties= \
     vm.rtm.compiler \
     vm.cds \
     vm.cds.default.archive.available \
+    vm.cds.nocoops.archive.available \
     vm.cds.custom.loaders \
     vm.cds.supports.aot.class.linking \
     vm.cds.supports.aot.code.caching \

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -28,6 +28,7 @@
  * @requires vm.bits == 64 & !vm.graal.enabled & vm.debug == true
  * @requires vm.flagless
  * @requires vm.cds
+ * @requires vm.cds.default.archive.available
  * @requires (os.family != "windows") & (os.family != "aix")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
+++ b/test/hotspot/jtreg/runtime/cds/TestDefaultArchiveLoading.java
@@ -94,8 +94,8 @@ public class TestDefaultArchiveLoading {
                          "server", archiveName(archiveSuffix));
     }
 
-    private static boolean isCOHArchiveAvailable(char coops, char coh,
-                                                 String archiveSuffix) throws Exception {
+    private static boolean isArchiveAvailable(char coops, char coh,
+                                              String archiveSuffix) throws Exception {
         Path archive= archivePath(archiveSuffix);
         return Files.exists(archive);
     }
@@ -113,12 +113,16 @@ public class TestDefaultArchiveLoading {
             case "nocoops_nocoh":
                 coh = coops = '-';
                 archiveSuffix = "_nocoops";
+                if (!isArchiveAvailable(coops, coh, archiveSuffix)) {
+                    throw new SkippedException("Skipping test due to " +
+                                               archivePath(archiveSuffix).toString() + " not available");
+                }
                 break;
             case "nocoops_coh":
                 coops = '-';
                 coh = '+';
                 archiveSuffix = "_nocoops_coh";
-                if (!isCOHArchiveAvailable(coops, coh, archiveSuffix)) {
+                if (!isArchiveAvailable(coops, coh, archiveSuffix)) {
                     throw new SkippedException("Skipping test due to " +
                                                archivePath(archiveSuffix).toString() + " not available");
                 }
@@ -127,11 +131,15 @@ public class TestDefaultArchiveLoading {
                 coops = '+';
                 coh = '-';
                 archiveSuffix = "";
+                if (!isArchiveAvailable(coops, coh, archiveSuffix)) {
+                    throw new SkippedException("Skipping test due to " +
+                                               archivePath(archiveSuffix).toString() + " not available");
+                }
                 break;
             case "coops_coh":
                 coh = coops = '+';
                 archiveSuffix = "_coh";
-                if (!isCOHArchiveAvailable(coops, coh, archiveSuffix)) {
+                if (!isArchiveAvailable(coops, coh, archiveSuffix)) {
                     throw new SkippedException("Skipping test due to " +
                                                archivePath(archiveSuffix).toString() + " not available");
                 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,7 @@
 /**
  * @test id=custom-cl-zgc
  * @requires vm.cds.custom.loaders
+ * @requires vm.cds.nocoops.archive.available
  * @requires vm.gc.Z
  * @summary Test dumptime_table entries are removed with zgc eager class unloading
  * @bug 8274935

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -123,6 +123,7 @@ public class VMProps implements Callable<Map<String, String>> {
         // vm.cds is true if the VM is compiled with cds support.
         map.put("vm.cds", this::vmCDS);
         map.put("vm.cds.default.archive.available", this::vmCDSDefaultArchiveAvailable);
+        map.put("vm.cds.nocoops.archive.available", this::vmCDSNocoopsArchiveAvailable);
         map.put("vm.cds.custom.loaders", this::vmCDSForCustomLoaders);
         map.put("vm.cds.supports.aot.class.linking", this::vmCDSSupportsAOTClassLinking);
         map.put("vm.cds.supports.aot.code.caching", this::vmCDSSupportsAOTCodeCaching);
@@ -456,6 +457,16 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmCDSDefaultArchiveAvailable() {
         Path archive = Paths.get(System.getProperty("java.home"), "lib", "server", "classes.jsa");
+        return "" + ("true".equals(vmCDS()) && Files.exists(archive));
+    }
+
+    /**
+     * Check for CDS no compressed oops archive existence.
+     *
+     * @return true if CDS archive classes_nocoops.jsa exists in the JDK to be tested.
+     */
+    protected String vmCDSNocoopsArchiveAvailable() {
+        Path archive = Paths.get(System.getProperty("java.home"), "lib", "server", "classes_nocoops.jsa");
         return "" + ("true".equals(vmCDS()) && Files.exists(archive));
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8364352](https://bugs.openjdk.org/browse/JDK-8364352) needs maintainer approval

### Issue
 * [JDK-8364352](https://bugs.openjdk.org/browse/JDK-8364352): Some tests fail when using a limited number of pregenerated .jsa CDS archives (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/203/head:pull/203` \
`$ git checkout pull/203`

Update a local copy of the PR: \
`$ git checkout pull/203` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 203`

View PR using the GUI difftool: \
`$ git pr show -t 203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/203.diff">https://git.openjdk.org/jdk25u/pull/203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/203#issuecomment-3297048442)
</details>
