### PR TITLE
8364111: InstanceMirrorKlass iterators should handle CDS and hidden classes consistently

### DIFF
--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -52,6 +52,9 @@ class InstanceMirrorKlass: public InstanceKlass {
 
   InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
 
+  template <class OopClosureType>
+  inline void do_metadata(oop obj, OopClosureType* closure);
+
  public:
   InstanceMirrorKlass();
 


### PR DESCRIPTION
Improves GC reliability with CDS and hidden classes, unblocks Shenandoah improvements that use these iterators.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux AArch64 server fastdebug, `all`
 - [x] Linux AArch64 server fastdebug, `all` + `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8364111](https://bugs.openjdk.org/browse/JDK-8364111) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8364111](https://bugs.openjdk.org/browse/JDK-8364111): InstanceMirrorKlass iterators should handle CDS and hidden classes consistently (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/205/head:pull/205` \
`$ git checkout pull/205`

Update a local copy of the PR: \
`$ git checkout pull/205` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 205`

View PR using the GUI difftool: \
`$ git pr show -t 205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/205.diff">https://git.openjdk.org/jdk25u/pull/205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/205#issuecomment-3302078061)
</details>
