### PR TITLE
8367689: Revert removal of several compilation-related vmStructs fields

### DIFF
--- a/src/hotspot/share/ci/ciClassList.hpp
+++ b/src/hotspot/share/ci/ciClassList.hpp
@@ -80,6 +80,7 @@ friend class ciObjectFactory; \
 // Any more access must be given explicitly.
 #define CI_PACKAGE_ACCESS_TO           \
 friend class ciObjectFactory;          \
+friend class VMStructs;                \
 friend class ciCallSite;               \
 friend class ciConstantPoolCache;      \
 friend class ciField;                  \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -667,6 +667,14 @@
      static_field(VMRegImpl,                   regName[0],                                    const char*)                           \
      static_field(VMRegImpl,                   stack0,                                        VMReg)                                 \
                                                                                                                                      \
+  /******************************************************************************************/                                       \
+  /* CI (NOTE: these CI fields are retained in VMStructs for the benefit of external tools, */                                       \
+  /* to ease their migration to a future alternative.)                                      */                                       \
+  /******************************************************************************************/                                       \
+                                                                                                                                     \
+  nonstatic_field(CompilerThread,              _env,                                          ciEnv*)                                \
+  nonstatic_field(ciEnv,                       _task,                                         CompileTask*)                          \
+                                                                                                                                     \
   /************/                                                                                                                     \
   /* Monitors */                                                                                                                     \
   /************/                                                                                                                     \
@@ -1149,6 +1157,12 @@
   declare_toplevel_type(ObjectSynchronizer)                               \
   declare_toplevel_type(BasicLock)                                        \
   declare_toplevel_type(BasicObjectLock)                                  \
+                                                                          \
+  /*********************/                                                 \
+  /* CI */                                                                \
+  /*********************/                                                 \
+                                                                          \
+  declare_toplevel_type(ciEnv)                                            \
                                                                           \
   /********************/                                                  \
   /* -XX flags        */                                                  \


### PR DESCRIPTION
Clean backport, reverts the removal of two CI fields which may be used by external tools. Low risk and small change.

Passes tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367689](https://bugs.openjdk.org/browse/JDK-8367689) needs maintainer approval

### Issue
 * [JDK-8367689](https://bugs.openjdk.org/browse/JDK-8367689): Revert removal of several compilation-related vmStructs fields (**Enhancement** - P4 - Approved)


### Reviewers
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - no project role)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/212/head:pull/212` \
`$ git checkout pull/212`

Update a local copy of the PR: \
`$ git checkout pull/212` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 212`

View PR using the GUI difftool: \
`$ git pr show -t 212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/212.diff">https://git.openjdk.org/jdk25u/pull/212.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/212#issuecomment-3306292666)
</details>
