### PR TITLE
8364184: [REDO] AArch64: [VectorAPI] sve vector math operations are not supported after JDK-8353217

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -940,7 +940,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   # ACLE and this flag are required to build the aarch64 SVE related functions in
   # libvectormath. Apple Silicon does not support SVE; use macOS as a proxy for
   # that check.
-  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_CPU" = "xlinux"; then
+  if test "x$OPENJDK_TARGET_CPU" = "xaarch64" && test "x$OPENJDK_TARGET_OS" = "xlinux"; then
     if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
       AC_LANG_PUSH(C)
       OLD_CFLAGS="$CFLAGS"


### PR DESCRIPTION
Backport 51d710e3cc8ee185a0a305e8efcfd03dda41570b

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8364184](https://bugs.openjdk.org/browse/JDK-8364184) needs maintainer approval

### Issue
 * [JDK-8364184](https://bugs.openjdk.org/browse/JDK-8364184): [REDO] AArch64: [VectorAPI] sve vector math operations are not supported after JDK-8353217 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/214/head:pull/214` \
`$ git checkout pull/214`

Update a local copy of the PR: \
`$ git checkout pull/214` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 214`

View PR using the GUI difftool: \
`$ git pr show -t 214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/214.diff">https://git.openjdk.org/jdk25u/pull/214.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/214#issuecomment-3307081385)
</details>
