### PR TITLE
8358532: JFileChooser in GTK L&F still displays HTML filename

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKFileChooserUI.java
@@ -1120,6 +1120,9 @@ class GTKFileChooserUI extends SynthFileChooserUI {
             if (showFileIcons) {
                 setIcon(getFileChooser().getIcon((File)value));
             }
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }
@@ -1137,6 +1140,9 @@ class GTKFileChooserUI extends SynthFileChooserUI {
             } else {
                 setText(getFileChooser().getName((File)value) + "/");
             }
+
+            putClientProperty("html.disable", getFileChooser().getClientProperty("html.disable"));
+
             return this;
         }
     }

--- a/test/jdk/javax/swing/JFileChooser/HTMLFileName.java
+++ b/test/jdk/javax/swing/JFileChooser/HTMLFileName.java
@@ -41,7 +41,7 @@ import javax.swing.filechooser.FileSystemView;
 
 /*
  * @test id=system
- * @bug 8139228
+ * @bug 8139228 8358532
  * @summary JFileChooser should not render Directory names in HTML format
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame


### PR DESCRIPTION
This pull request contains a backport of commit [6fe9143b](https://github.com/openjdk/jdk/commit/6fe9143bbbe269af62d2084834fc0c9afc51b5f3) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Tejesh R on 16 Jun 2025 and was reviewed by Alexey Ivanov, Damon Nguyen and Alexander Zuev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358532](https://bugs.openjdk.org/browse/JDK-8358532) needs maintainer approval

### Issue
 * [JDK-8358532](https://bugs.openjdk.org/browse/JDK-8358532): JFileChooser in GTK L&amp;F still displays HTML filename (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/216/head:pull/216` \
`$ git checkout pull/216`

Update a local copy of the PR: \
`$ git checkout pull/216` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 216`

View PR using the GUI difftool: \
`$ git pr show -t 216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/216.diff">https://git.openjdk.org/jdk25u/pull/216.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/216#issuecomment-3309455736)
</details>
