### PR TITLE
8367031: [backout] Change java.time month/day field types to 'byte'

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -182,11 +182,11 @@ public final class LocalDate
     /**
      * @serial The month-of-year.
      */
-    private final byte month;
+    private final short month;
     /**
      * @serial The day-of-month.
      */
-    private final byte day;
+    private final short day;
 
     //-----------------------------------------------------------------------
     /**
@@ -490,8 +490,8 @@ public final class LocalDate
      */
     private LocalDate(int year, int month, int dayOfMonth) {
         this.year = year;
-        this.month = (byte) month;
-        this.day = (byte) dayOfMonth;
+        this.month = (short) month;
+        this.day = (short) dayOfMonth;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/MonthDay.java
+++ b/src/java.base/share/classes/java/time/MonthDay.java
@@ -146,11 +146,11 @@ public final class MonthDay
     /**
      * @serial The month-of-year, not null.
      */
-    private final byte month;
+    private final int month;
     /**
      * @serial The day-of-month.
      */
-    private final byte day;
+    private final int day;
 
     //-----------------------------------------------------------------------
     /**
@@ -319,8 +319,8 @@ public final class MonthDay
      * @param dayOfMonth  the day-of-month to represent, validated from 1 to 29-31
      */
     private MonthDay(int month, int dayOfMonth) {
-        this.month = (byte) month;
-        this.day = (byte) dayOfMonth;
+        this.month = month;
+        this.day = dayOfMonth;
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/YearMonth.java
+++ b/src/java.base/share/classes/java/time/YearMonth.java
@@ -153,7 +153,7 @@ public final class YearMonth
     /**
      * @serial The month-of-year, not null.
      */
-    private final byte month;
+    private final int month;
 
     //-----------------------------------------------------------------------
     /**
@@ -306,7 +306,7 @@ public final class YearMonth
      */
     private YearMonth(int year, int month) {
         this.year = year;
-        this.month = (byte) month;
+        this.month = month;
     }
 
     /**

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,11 +137,11 @@ public final class HijrahDate
     /**
      * The month-of-year.
      */
-    private final transient byte monthOfYear;
+    private final transient int monthOfYear;
     /**
      * The day-of-month.
      */
-    private final transient byte dayOfMonth;
+    private final transient int dayOfMonth;
 
     //-------------------------------------------------------------------------
     /**
@@ -273,8 +273,8 @@ public final class HijrahDate
 
         this.chrono = chrono;
         this.prolepticYear = prolepticYear;
-        this.monthOfYear = (byte) monthOfYear;
-        this.dayOfMonth = (byte) dayOfMonth;
+        this.monthOfYear = monthOfYear;
+        this.dayOfMonth = dayOfMonth;
     }
 
     /**
@@ -287,8 +287,8 @@ public final class HijrahDate
 
         this.chrono = chrono;
         this.prolepticYear = dateInfo[0];
-        this.monthOfYear = (byte) dateInfo[1];
-        this.dayOfMonth = (byte) dateInfo[2];
+        this.monthOfYear = dateInfo[1];
+        this.dayOfMonth = dateInfo[2];
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
Propagate [backout] Change java.time month/day field types to 'byte' to jdk 25.
Previously reviewed as: https://github.com/openjdk/jdk/pull/27346

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367031](https://bugs.openjdk.org/browse/JDK-8367031) needs maintainer approval

### Issue
 * [JDK-8367031](https://bugs.openjdk.org/browse/JDK-8367031): [backout] Change java.time month/day field types to 'byte' (**Bug** - P2 - Approved)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/217/head:pull/217` \
`$ git checkout pull/217`

Update a local copy of the PR: \
`$ git checkout pull/217` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 217`

View PR using the GUI difftool: \
`$ git pr show -t 217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/217.diff">https://git.openjdk.org/jdk25u/pull/217.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/217#issuecomment-3309817367)
</details>
