### PR TITLE
8162380: [TEST_BUG] MouseEvent/.../AltGraphModifierTest.java has only "Fail" button

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -803,7 +803,6 @@ java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_2.java 7131438,802
 java/awt/Modal/WsDisabledStyle/CloseBlocker/CloseBlocker.java 7187741 linux-all,macosx-all
 java/awt/xembed/server/TestXEmbedServerJava.java 8001150,8004031 generic-all
 java/awt/Modal/PrintDialogsTest/PrintDialogsTest.java 8068378 generic-all
-java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java 8162380 generic-all
 java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-all,linux-all
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/Frame/FrameStateTest/FrameStateTest.java 8203920 macosx-all,linux-all

--- a/test/jdk/java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java
+++ b/test/jdk/java/awt/event/MouseEvent/AltGraphModifierTest/AltGraphModifierTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,51 +22,57 @@
  */
 
 /*
- @test
- @bug 8041928 8158616
- @requires (os.family != "mac")
- @summary Confirm that the Alt-Gr Modifier bit is set correctly.
- @run main/manual AltGraphModifierTest
+ * @test
+ * @bug 8041928 8158616
+ * @requires (os.family != "mac")
+ * @summary Confirm that the Alt-Gr Modifier bit is set correctly.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual AltGraphModifierTest
  */
 
-import java.awt.Button;
-import java.awt.Dialog;
 import java.awt.Frame;
-import java.awt.Panel;
-import java.awt.TextArea;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
 public class AltGraphModifierTest {
-    private static void init() throws Exception {
-        String[] instructions
-                = {
-                    "This test is for verifying Alt-Gr modifier of an event.",
-                    "Linux :-",
-                    "1. Please check if Alt-Gr key is present on keyboard.",
-                    "2. If present, press the Alt-Gr key and perform",
-                    "   mouse click on the TestWindow.",
-                    "3. Navigate to System Settings-> Keyboard-> Shortcuts->",
-                    "   Typing.",
-                    "4. Select an option for the Alternative Characters Key",
-                    "   For example. Right Alt",
-                    "5. Close the settings and navigate to test",
-                    "6. Press Right Alt Key & perform mouse click on the",
-                    "   TestWindow",
-                    "7. Test will exit by itself with appropriate result.",
-                    " ",
-                };
 
-        Sysout.createDialog();
-        Sysout.printInstructions(instructions);
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This test is for verifying Alt-Gr modifier of an event.
+                Please check if Alt-Gr key is present on keyboard.
+                If not present, press Pass.
+                On Windows:
+                    Press Alt-Gr or Right Alt key and simultaneously
+                        perform mouse click on the "TestWindow".
+                On Linux:
+                    Navigate to
+                      System Settings-> Keyboard-> Special Character Entry
+                    Select "Right Alt" option for the "Alternate Characters Key"
+                    Close the settings and navigate to test
+                    Press Right Alt Key & simultaneously
+                        perform mouse click on the "TestWindow".
+
+                    If the system does not have such setting, press Pass.
+                    After the test, change the Setting of "Alternate Characters Key"
+                    back to "Layout default".
+
+                If "Alt-Gr Modifier bit is set" message is displayed in logArea,
+                press Pass else press Fail.
+                """;
+
+         PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(AltGraphModifierTest::initTestWindow)
+                .logArea()
+                .build()
+                .awaitAndCheck();
     }
 
-    static Frame mainFrame;
-    public static void initTestWindow() {
-        mainFrame = new Frame();
+    public static Frame initTestWindow() {
+        Frame mainFrame = new Frame();
         mainFrame.setTitle("TestWindow");
         mainFrame.setBounds(700, 10, 300, 300);
         mainFrame.addMouseListener(new MouseAdapter() {
@@ -74,186 +80,12 @@ public class AltGraphModifierTest {
             public void mousePressed(MouseEvent e) {
                 int ex = e.getModifiersEx();
                 if ((ex & InputEvent.ALT_GRAPH_DOWN_MASK) == 0) {
-                    AltGraphModifierTest.fail("Alt-Gr Modifier bit is not set.");
+                    PassFailJFrame.log("Alt-Gr Modifier bit is not set.");
                 } else {
-                    AltGraphModifierTest.pass();
+                    PassFailJFrame.log("Alt-Gr Modifier bit is set");
                 }
             }
         });
-        mainFrame.setVisible(true);
-    }
-
-    public static void dispose() {
-        Sysout.dispose();
-        mainFrame.dispose();
-    }
-
-    /**
-     * ***************************************************
-     * Standard Test Machinery Section DO NOT modify anything in this section --
-     * it's a standard chunk of code which has all of the synchronisation
-     * necessary for the test harness. By keeping it the same in all tests, it
-     * is easier to read and understand someone else's test, as well as insuring
-     * that all tests behave correctly with the test harness. There is a section
-     * following this for test-defined classes
-     * ****************************************************
-     */
-    private static boolean theTestPassed = false;
-    private static boolean testGeneratedInterrupt = false;
-    private static String failureMessage = "";
-    private static Thread mainThread = null;
-    final private static int sleepTime = 300000;
-
-    public static void main(String args[]) throws Exception {
-        mainThread = Thread.currentThread();
-        try {
-            init();
-            initTestWindow();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        try {
-            mainThread.sleep(sleepTime);
-        } catch (InterruptedException e) {
-            dispose();
-            if (testGeneratedInterrupt && !theTestPassed) {
-                throw new Exception(failureMessage);
-            }
-        }
-        if (!testGeneratedInterrupt) {
-            dispose();
-            throw new RuntimeException("Timed out after " + sleepTime / 1000
-                    + " seconds");
-        }
-    }
-
-    public static synchronized void pass() {
-        theTestPassed = true;
-        testGeneratedInterrupt = true;
-        mainThread.interrupt();
-    }
-
-    public static synchronized void fail(String whyFailed) {
-        theTestPassed = false;
-        testGeneratedInterrupt = true;
-        failureMessage = whyFailed;
-        mainThread.interrupt();
-    }
-}
-
-// *********** End Standard Test Machinery Section **********
-/**
- * **************************************************
- * Standard Test Machinery DO NOT modify anything below -- it's a standard chunk
- * of code whose purpose is to make user interaction uniform, and thereby make
- * it simpler to read and understand someone else's test.
- * **************************************************
- */
-/**
- * This is part of the standard test machinery. It creates a dialog (with the
- * instructions), and is the interface for sending text messages to the user. To
- * print the instructions, send an array of strings to Sysout.createDialog
- * WithInstructions method. Put one line of instructions per array entry. To
- * display a message for the tester to see, simply call Sysout.println with the
- * string to be displayed. This mimics System.out.println but works within the
- * test harness as well as standalone.
- */
-class Sysout {
-    private static TestDialog dialog;
-    private static Frame frame;
-
-    public static void createDialog() {
-        frame = new Frame();
-        dialog = new TestDialog(frame, "Instructions");
-        String[] defInstr = {"Instructions will appear here. ", ""};
-        dialog.printInstructions(defInstr);
-        dialog.show();
-        println("Any messages for the tester will display here.");
-    }
-
-    public static void printInstructions(String[] instructions) {
-        dialog.printInstructions(instructions);
-    }
-
-    public static void println(String messageIn) {
-        dialog.displayMessage(messageIn);
-    }
-
-    public static void dispose() {
-        dialog.dispose();
-        frame.dispose();
-    }
-}
-
-/**
- * This is part of the standard test machinery. It provides a place for the test
- * instructions to be displayed, and a place for interactive messages to the
- * user to be displayed. To have the test instructions displayed, see Sysout. To
- * have a message to the user be displayed, see Sysout. Do not call anything in
- * this dialog directly.
- */
-class TestDialog extends Dialog implements ActionListener {
-    TextArea instructionsText;
-    TextArea messageText;
-    int maxStringLength = 80;
-    Panel buttonP;
-    Button failB;
-
-    // DO NOT call this directly, go through Sysout
-    public TestDialog(Frame frame, String name) {
-        super(frame, name);
-        int scrollBoth = TextArea.SCROLLBARS_BOTH;
-        instructionsText = new TextArea("", 15, maxStringLength, scrollBoth);
-        add("North", instructionsText);
-
-        messageText = new TextArea("", 5, maxStringLength, scrollBoth);
-        add("Center", messageText);
-
-        buttonP = new Panel();
-        failB = new Button("Fail");
-        failB.setActionCommand("fail");
-        failB.addActionListener(this);
-        buttonP.add("Center", failB);
-
-        add("South", buttonP);
-        pack();
-        setVisible(true);
-    }
-
-    // DO NOT call this directly, go through Sysout
-    public void printInstructions(String[] instructions) {
-        instructionsText.setText("");
-        String printStr, remainingStr;
-        for (int i = 0; i < instructions.length; i++) {
-            remainingStr = instructions[i];
-            while (remainingStr.length() > 0) {
-                if (remainingStr.length() >= maxStringLength) {
-                    int posOfSpace = remainingStr.
-                            lastIndexOf(' ', maxStringLength - 1);
-
-                    if (posOfSpace <= 0) {
-                        posOfSpace = maxStringLength - 1;
-                    }
-
-                    printStr = remainingStr.substring(0, posOfSpace + 1);
-                    remainingStr = remainingStr.substring(posOfSpace + 1);
-                }
-                else {
-                    printStr = remainingStr;
-                    remainingStr = "";
-                }
-                instructionsText.append(printStr + "\n");
-            }
-        }
-    }
-
-    public void displayMessage(String messageIn) {
-        messageText.append(messageIn + "\n");
-    }
-
-    public void actionPerformed(ActionEvent e) {
-        if (e.getActionCommand() == "fail") {
-            AltGraphModifierTest.fail("User Clicked Fail");
-        }
+        return mainFrame;
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [34c3ac03](https://github.com/openjdk/jdk/commit/34c3ac0316dbd29ae670db51bd9230a1e77382d9) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Prasanta Sadhukhan on 10 Sep 2025 and was reviewed by Alexander Zvegintsev and Alexey Ivanov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8162380](https://bugs.openjdk.org/browse/JDK-8162380) needs maintainer approval

### Issue
 * [JDK-8162380](https://bugs.openjdk.org/browse/JDK-8162380): [TEST_BUG] MouseEvent/.../AltGraphModifierTest.java has only "Fail" button (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/219/head:pull/219` \
`$ git checkout pull/219`

Update a local copy of the PR: \
`$ git checkout pull/219` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 219`

View PR using the GUI difftool: \
`$ git pr show -t 219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/219.diff">https://git.openjdk.org/jdk25u/pull/219.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/219#issuecomment-3310812476)
</details>
