### PR TITLE
8367782: VerifyJarEntryName.java: Fix modifyJarEntryName to operate on bytes and re-introduce verifySignatureEntryName

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/VerifyJarEntryName.java
+++ b/test/jdk/sun/security/tools/jarsigner/VerifyJarEntryName.java
@@ -38,12 +38,13 @@ import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import jdk.test.lib.SecurityTools;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class VerifyJarEntryName {
 
@@ -85,13 +86,29 @@ public class VerifyJarEntryName {
      */
     @Test
     void verifyManifestEntryName() throws Exception {
-        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "MANIFEST.MF");
+        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "META-INF/MANIFEST.MF");
         SecurityTools.jarsigner("-verify -verbose " + MODIFIED_JAR)
                 .shouldContain("This JAR file contains internal " +
                         "inconsistencies that may result in different " +
                         "contents when reading via JarFile and JarInputStream:")
                 .shouldContain("- Manifest is missing when " +
                         "reading via JarInputStream")
+                .shouldHaveExitValue(0);
+    }
+
+    /*
+     * Modify a single byte in signature filename in LOC, and
+     * validate that jarsigner -verify emits a warning message.
+     */
+    @Test
+    void verifySignatureEntryName() throws Exception {
+        modifyJarEntryName(ORIGINAL_JAR, MODIFIED_JAR, "META-INF/MYKEY.SF");
+        SecurityTools.jarsigner("-verify -verbose " + MODIFIED_JAR)
+                .shouldContain("This JAR file contains internal " +
+                        "inconsistencies that may result in different " +
+                        "contents when reading via JarFile and JarInputStream:")
+                .shouldContain("- Entry XETA-INF/MYKEY.SF is present when reading " +
+                        "via JarInputStream but missing when reading via JarFile")
                 .shouldHaveExitValue(0);
     }
 
@@ -111,9 +128,14 @@ public class VerifyJarEntryName {
     private void modifyJarEntryName(Path origJar, Path modifiedJar,
             String entryName) throws Exception {
         byte[] jarBytes = Files.readAllBytes(origJar);
-        var jarString = new String(jarBytes, StandardCharsets.UTF_8);
-        var pos = jarString.indexOf(entryName);
-        assertTrue(pos != -1, entryName + " is not present in the JAR");
+        byte[] entryNameBytes = entryName.getBytes(StandardCharsets.UTF_8);
+        int pos = 0;
+        try {
+            while (!Arrays.equals(jarBytes, pos, pos + entryNameBytes.length,
+                    entryNameBytes, 0, entryNameBytes.length)) pos++;
+        } catch (ArrayIndexOutOfBoundsException ignore) {
+            fail(entryName + " is not present in the JAR");
+        }
         jarBytes[pos] = 'X';
         Files.write(modifiedJar, jarBytes);
     }


### PR DESCRIPTION
Hi, I'm proposing this test-only improvement for consistency with the older releases, where I'm doing backports of the main issue ([JDK-8339280](https://bugs.openjdk.org/browse/JDK-8339280 "jarsigner -verify performs cross-checking between CEN and LOC"), openjdk/jdk@bbd5b174c50346152a624317b6bd76ec48f7e551) and also including this version of the test. Those backports are openjdk/jdk21u-dev#2235, openjdk/jdk17u-dev#3954, openjdk/jdk11u-dev#3098 and openjdk/jdk8u-dev#699.

The backport is clean and improves the reliability and coverage of the `VerifyJarEntryName.java` test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367782](https://bugs.openjdk.org/browse/JDK-8367782) needs maintainer approval

### Issue
 * [JDK-8367782](https://bugs.openjdk.org/browse/JDK-8367782): VerifyJarEntryName.java: Fix modifyJarEntryName to operate on bytes and re-introduce verifySignatureEntryName (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/221/head:pull/221` \
`$ git checkout pull/221`

Update a local copy of the PR: \
`$ git checkout pull/221` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 221`

View PR using the GUI difftool: \
`$ git pr show -t 221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/221.diff">https://git.openjdk.org/jdk25u/pull/221.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/221#issuecomment-3312677834)
</details>
