### PR TITLE
8362972: C2 fails with unexpected node in SuperWord truncation: IsFiniteF, IsFiniteD

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2593,6 +2593,8 @@ static bool can_subword_truncate(Node* in, const Type* type) {
   case Op_ReverseI:
   case Op_CountLeadingZerosI:
   case Op_CountTrailingZerosI:
+  case Op_IsFiniteF:
+  case Op_IsFiniteD:
   case Op_IsInfiniteF:
   case Op_IsInfiniteD:
   case Op_ExtractS:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [9f796da3](https://github.com/openjdk/jdk/commit/9f796da3774b2e2f92dca178fdccd93989919256) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Wang Haomin on 23 Jul 2025 and was reviewed by Tobias Hartmann and Jasmine Karthikeyan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362972](https://bugs.openjdk.org/browse/JDK-8362972) needs maintainer approval

### Issue
 * [JDK-8362972](https://bugs.openjdk.org/browse/JDK-8362972): C2 fails with unexpected node in SuperWord truncation: IsFiniteF, IsFiniteD (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/222/head:pull/222` \
`$ git checkout pull/222`

Update a local copy of the PR: \
`$ git checkout pull/222` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 222`

View PR using the GUI difftool: \
`$ git pr show -t 222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/222.diff">https://git.openjdk.org/jdk25u/pull/222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/222#issuecomment-3314979503)
</details>
