### PR TITLE
8367988: NewFileSystemTests.readOnlyZipFileFailure fails when run by root user

### DIFF
--- a/test/jdk/jdk/nio/zipfs/NewFileSystemTests.java
+++ b/test/jdk/jdk/nio/zipfs/NewFileSystemTests.java
@@ -25,6 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import java.io.IOException;
 import java.net.URI;
@@ -35,6 +36,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Map;
+import jdk.test.lib.Platform;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
@@ -48,6 +50,7 @@ import static org.testng.Assert.assertTrue;
  * @bug 8218875
  * @summary ZIP File System tests that leverage Files.newFileSystem
  * @modules jdk.zipfs
+ * @library /test/lib
  * @compile NewFileSystemTests.java
  * @run testng NewFileSystemTests
  */
@@ -219,6 +222,9 @@ public class NewFileSystemTests {
      */
     @Test
     public void readOnlyZipFileFailure() throws IOException {
+        if (Platform.isRoot()) {
+            throw new SkipException("Test skipped when executed by root user.");
+        }
         // Underlying file is read-only.
         Path readOnlyZip = Utils.createJarFile("read_only.zip", Map.of("file.txt", "Hello World"));
         // In theory this can fail, and we should avoid unwanted false-negatives.


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b03b6f54](https://github.com/openjdk/jdk/commit/b03b6f54c5f538146c3088c4dc2cea70ba70d07a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Francesco Andreuzzi on 20 Sep 2025 and was reviewed by Jaikiran Pai and Brian Burkhalter.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8367988](https://bugs.openjdk.org/browse/JDK-8367988) needs maintainer approval

### Issue
 * [JDK-8367988](https://bugs.openjdk.org/browse/JDK-8367988): NewFileSystemTests.readOnlyZipFileFailure fails when run by root user (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/223/head:pull/223` \
`$ git checkout pull/223`

Update a local copy of the PR: \
`$ git checkout pull/223` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 223`

View PR using the GUI difftool: \
`$ git pr show -t 223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/223.diff">https://git.openjdk.org/jdk25u/pull/223.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/223#issuecomment-3315010483)
</details>
