### PR TITLE
8359423: Improve error message in case of missing jsa shared archive

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1270,7 +1270,7 @@ void MetaspaceShared::unrecoverable_loading_error(const char* message) {
   } else if (CDSConfig::new_aot_flags_used()) {
     vm_exit_during_initialization("Unable to use AOT cache.", nullptr);
   } else {
-    vm_exit_during_initialization("Unable to use shared archive.", nullptr);
+    vm_exit_during_initialization("Unable to use shared archive. Unrecoverable archive loading error (run with -Xlog:aot,cds for details)", message);
   }
 }
 
@@ -1394,6 +1394,7 @@ FileMapInfo* MetaspaceShared::open_static_archive() {
   FileMapInfo* mapinfo = new FileMapInfo(static_archive, true);
   if (!mapinfo->open_as_input()) {
     delete(mapinfo);
+    log_info(cds)("Opening of static archive %s failed", static_archive);
     return nullptr;
   }
   return mapinfo;


### PR DESCRIPTION
Backport of 8359423

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8359423](https://bugs.openjdk.org/browse/JDK-8359423) needs maintainer approval

### Issue
 * [JDK-8359423](https://bugs.openjdk.org/browse/JDK-8359423): Improve error message in case of missing jsa shared archive (**Enhancement** - P4 - Approved)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/226/head:pull/226` \
`$ git checkout pull/226`

Update a local copy of the PR: \
`$ git checkout pull/226` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 226`

View PR using the GUI difftool: \
`$ git pr show -t 226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/226.diff">https://git.openjdk.org/jdk25u/pull/226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/226#issuecomment-3350385272)
</details>
