### PR TITLE
8360178: TestArguments.atojulong gtest has incorrect format string

### DIFF
--- a/test/hotspot/gtest/runtime/test_arguments.cpp
+++ b/test/hotspot/gtest/runtime/test_arguments.cpp
@@ -22,13 +22,14 @@
  */
 
 #include "jvm.h"
-#include "unittest.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/flags/jvmFlag.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #include <errno.h>
+
+#include "unittest.hpp"
 
 class ArgumentsTest : public ::testing::Test {
 public:
@@ -57,7 +58,7 @@ public:
 
 TEST_F(ArgumentsTest, atojulong) {
   char ullong_max[32];
-  int ret = jio_snprintf(ullong_max, sizeof(ullong_max), JULONG_FORMAT, ULLONG_MAX);
+  int ret = jio_snprintf(ullong_max, sizeof(ullong_max), "%llu", ULLONG_MAX);
   ASSERT_NE(-1, ret);
 
   julong value;


### PR DESCRIPTION
A clean backport for [JDK-8360178](https://bugs.openjdk.org/browse/JDK-8360178)

This patch is to fix format directive when printing ULLONG_MAX by TestArguments.atojulong gtest. Instead of using JULONG_FORMAT, which might not be the proper type (though sized properly), use "%llu" to avoid potential warning.

Backporting this patch can help fix test gtest gap. 

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8360178](https://bugs.openjdk.org/browse/JDK-8360178) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8360178](https://bugs.openjdk.org/browse/JDK-8360178): TestArguments.atojulong gtest has incorrect format string (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/228/head:pull/228` \
`$ git checkout pull/228`

Update a local copy of the PR: \
`$ git checkout pull/228` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 228`

View PR using the GUI difftool: \
`$ git pr show -t 228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/228.diff">https://git.openjdk.org/jdk25u/pull/228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/228#issuecomment-3319430858)
</details>
