### PR TITLE
8368071: Compilation throughput regressed 2X-8X after JDK-8355003

### DIFF
--- a/src/hotspot/share/compiler/compilationPolicy.cpp
+++ b/src/hotspot/share/compiler/compilationPolicy.cpp
@@ -1335,17 +1335,24 @@ CompLevel CompilationPolicy::standard_transition(const methodHandle& method, Com
   return next_level;
 }
 
+template<typename Predicate> static inline bool apply_predicate(const methodHandle& method, CompLevel cur_level, int i, int b, bool delay_profiling, double delay_profiling_scale) {
+  if (delay_profiling) {
+    return Predicate::apply_scaled(method, cur_level, i, b, delay_profiling_scale);
+  } else {
+    return Predicate::apply(method, cur_level, i, b);
+  }
+}
+
 template<typename Predicate>
 CompLevel CompilationPolicy::transition_from_none(const methodHandle& method, CompLevel cur_level, bool delay_profiling, bool disable_feedback) {
   precond(cur_level == CompLevel_none);
   CompLevel next_level = cur_level;
   int i = method->invocation_count();
   int b = method->backedge_count();
-  double scale = delay_profiling ? Tier0ProfileDelayFactor : 1.0;
   // If we were at full profile level, would we switch to full opt?
   if (transition_from_full_profile<Predicate>(method, CompLevel_full_profile) == CompLevel_full_optimization) {
     next_level = CompLevel_full_optimization;
-  } else if (!CompilationModeFlag::disable_intermediate() && Predicate::apply_scaled(method, cur_level, i, b, scale)) {
+  } else if (!CompilationModeFlag::disable_intermediate() && apply_predicate<Predicate>(method, cur_level, i, b, delay_profiling, Tier0ProfileDelayFactor)) {
     // C1-generated fully profiled code is about 30% slower than the limited profile
     // code that has only invocation and backedge counters. The observation is that
     // if C2 queue is large enough we can spend too much time in the fully profiled code
@@ -1387,13 +1394,12 @@ CompLevel CompilationPolicy::transition_from_limited_profile(const methodHandle&
   CompLevel next_level = cur_level;
   int i = method->invocation_count();
   int b = method->backedge_count();
-  double scale = delay_profiling ? Tier2ProfileDelayFactor : 1.0;
   MethodData* mdo = method->method_data();
   if (mdo != nullptr) {
     if (mdo->would_profile()) {
       if (disable_feedback || (CompileBroker::queue_size(CompLevel_full_optimization) <=
                               Tier3DelayOff * compiler_count(CompLevel_full_optimization) &&
-                              Predicate::apply_scaled(method, cur_level, i, b, scale))) {
+                              apply_predicate<Predicate>(method, cur_level, i, b, delay_profiling, Tier2ProfileDelayFactor))) {
         next_level = CompLevel_full_profile;
       }
     } else {
@@ -1403,7 +1409,7 @@ CompLevel CompilationPolicy::transition_from_limited_profile(const methodHandle&
     // If there is no MDO we need to profile
     if (disable_feedback || (CompileBroker::queue_size(CompLevel_full_optimization) <=
                             Tier3DelayOff * compiler_count(CompLevel_full_optimization) &&
-                            Predicate::apply_scaled(method, cur_level, i, b, scale))) {
+                            apply_predicate<Predicate>(method, cur_level, i, b, delay_profiling, Tier2ProfileDelayFactor))) {
       next_level = CompLevel_full_profile;
     }
   }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [bdfe05b5](https://github.com/openjdk/jdk/commit/bdfe05b595d86c62f7dad78549023a3426423679) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Man Cao on 22 Sep 2025 and was reviewed by Igor Veresov and Aleksey Shipilev.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368071](https://bugs.openjdk.org/browse/JDK-8368071) needs maintainer approval

### Issue
 * [JDK-8368071](https://bugs.openjdk.org/browse/JDK-8368071): Compilation throughput regressed 2X-8X after JDK-8355003 (**Bug** - P2 - Approved)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/229/head:pull/229` \
`$ git checkout pull/229`

Update a local copy of the PR: \
`$ git checkout pull/229` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 229`

View PR using the GUI difftool: \
`$ git pr show -t 229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/229.diff">https://git.openjdk.org/jdk25u/pull/229.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/229#issuecomment-3320847511)
</details>
