### PR TITLE
8361253: CommandLineOptionTest library should report observed values on failure

### DIFF
--- a/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
+++ b/test/lib/jdk/test/lib/cli/CommandLineOptionTest.java
@@ -122,8 +122,8 @@ public abstract class CommandLineOptionTest {
                 outputAnalyzer.shouldHaveExitValue(exitCode.value);
         } catch (RuntimeException e) {
             String errorMessage = String.format(
-                    "JVM process should have exit value '%d'.%n%s",
-                    exitCode.value, exitErrorMessage);
+                    "JVM process should have exit value '%d', but has '%d'.%n%s",
+                    exitCode.value, outputAnalyzer.getExitValue(), exitErrorMessage);
             throw new AssertionError(errorMessage, e);
         }
 
@@ -302,9 +302,12 @@ public abstract class CommandLineOptionTest {
                     CommandLineOptionTest.PRINT_FLAGS_FINAL_FORMAT,
                     optionName, expectedValue));
         } catch (RuntimeException e) {
+            String observedValue = outputAnalyzer.firstMatch(String.format(
+                CommandLineOptionTest.PRINT_FLAGS_FINAL_FORMAT,
+                optionName, "\\S"));
             String errorMessage = String.format(
-                    "Option '%s' is expected to have '%s' value%n%s",
-                    optionName, expectedValue,
+                    "Option '%s' is expected to have '%s' value, but is '%s'.%n%s",
+                    optionName, expectedValue, observedValue,
                     optionErrorString);
             throw new AssertionError(errorMessage, e);
         }


### PR DESCRIPTION
A clean backport for [JDK-8361253](https://bugs.openjdk.org/browse/JDK-8361253)

This patch is to make CommandLineOptionTest library report observed values on failure rather than only report expected value when failing.

Backporting this patch can help fix debugging gap. 

Testing: mach5 tier1,tier2,tier3 & Oracle internal testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8361253](https://bugs.openjdk.org/browse/JDK-8361253) needs maintainer approval

### Issue
 * [JDK-8361253](https://bugs.openjdk.org/browse/JDK-8361253): CommandLineOptionTest library should report observed values on failure (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/231/head:pull/231` \
`$ git checkout pull/231`

Update a local copy of the PR: \
`$ git checkout pull/231` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 231`

View PR using the GUI difftool: \
`$ git pr show -t 231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/231.diff">https://git.openjdk.org/jdk25u/pull/231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/231#issuecomment-3322395960)
</details>
