### PR TITLE
8346839: [TESTBUG] "java/awt/textfield/setechochartest4/setechochartest4.java" failed because the test frame disappears on clicking "Click Several Times" button

### DIFF
--- a/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ import java.awt.Frame;
 import java.awt.TextField;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.lang.reflect.InvocationTargetException;
 
 /*
  * @test
@@ -54,16 +53,17 @@ public class SetEchoCharTest4 extends Frame implements ActionListener {
 
                     Make sure the actual text matches what you typed in for each field.
                     Press Pass if everything's ok, otherwise Fail
-           """;
+                    """;
 
     public SetEchoCharTest4() {
+        super("SetEchoCharTest4");
         setLayout(new FlowLayout());
         tf1.setEchoChar('*');
         tf2.setEchoChar('$');
         tf3.setEchoChar('#');
         addStuff();
         b.addActionListener(this);
-        setSize (200,200);
+        setSize (300, 150);
     }
 
     private void addStuff() {
@@ -78,7 +78,6 @@ public class SetEchoCharTest4 extends Frame implements ActionListener {
         PassFailJFrame.log("TextField2 = " + tf2.getText());
         PassFailJFrame.log("TextField3 = " + tf3.getText());
         PassFailJFrame.log("--------------");
-        setVisible(false);
         remove(tf1);
         remove(tf2);
         remove(tf3);
@@ -86,16 +85,14 @@ public class SetEchoCharTest4 extends Frame implements ActionListener {
         addStuff();
     }
 
-    public static void main(String[] args) throws InterruptedException,
-            InvocationTargetException {
+    public static void main(String[] args) throws Exception {
         PassFailJFrame.builder()
-                .title("Set Echo Character Test")
-                .testUI(SetEchoCharTest4::new)
-                .instructions(INSTRUCTIONS)
-                .rows((int) INSTRUCTIONS.lines().count() + 1)
-                .columns(40)
-                .logArea()
-                .build()
-                .awaitAndCheck();
+                      .title("Set Echo Character Test")
+                      .testUI(SetEchoCharTest4::new)
+                      .instructions(INSTRUCTIONS)
+                      .columns(40)
+                      .logArea()
+                      .build()
+                      .awaitAndCheck();
     }
 }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [58270b75](https://github.com/openjdk/jdk/commit/58270b757c0bdf82bf753fa304b829e3b64196e4) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Harshitha Onkar on 22 Sep 2025 and was reviewed by Prasanta Sadhukhan and Sergey Bylokhov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8346839](https://bugs.openjdk.org/browse/JDK-8346839) needs maintainer approval

### Issue
 * [JDK-8346839](https://bugs.openjdk.org/browse/JDK-8346839): [TESTBUG] "java/awt/textfield/setechochartest4/setechochartest4.java" failed because the test frame disappears on clicking "Click Several Times" button (**Bug** - P5 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/232/head:pull/232` \
`$ git checkout pull/232`

Update a local copy of the PR: \
`$ git checkout pull/232` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 232`

View PR using the GUI difftool: \
`$ git pr show -t 232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/232.diff">https://git.openjdk.org/jdk25u/pull/232.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/232#issuecomment-3322668324)
</details>
