### PR TITLE
8361520: Stabilize SystemGC benchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -48,6 +52,12 @@ public class AllDead {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -48,6 +52,12 @@ public class AllLive {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
@@ -26,15 +26,19 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -48,6 +52,12 @@ public class DifferentObjectSizesArray {
      */
 
     static Object[] largeObjArray;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -49,6 +53,12 @@ public class DifferentObjectSizesHashMap {
      */
 
     static HashMap<Integer, byte[]> largeMap;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -48,6 +52,12 @@ public class DifferentObjectSizesTreeMap {
      * The jvmArgs are provided to avoid GCs during object creation.
      */
     static TreeMap<Integer, byte[]> largeMap;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -49,6 +53,12 @@ public class HalfDeadFirstPart {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -49,6 +53,12 @@ public class HalfDeadInterleaved {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -49,6 +53,12 @@ public class HalfDeadInterleavedChunks {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -49,6 +53,12 @@ public class HalfDeadSecondPart {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
@@ -26,16 +26,20 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -49,6 +53,12 @@ public class HalfHashedHalfDead {
      */
 
     static ArrayList<Object[]> holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
@@ -25,14 +25,23 @@ package org.openjdk.bench.vm.gc.systemgc;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
 public class NoObjects {
 
     /*
@@ -42,6 +51,12 @@ public class NoObjects {
      * The heap settings provided are the same as for the other
      * test for consistency.
      */
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Benchmark
     public void gc() {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
@@ -26,15 +26,19 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 @Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
@@ -48,6 +52,12 @@ public class OneBigObject {
      */
 
     static Object[] holder;
+
+    @Setup(Level.Trial)
+    public void preRun() {
+        // Compact right now, kicking out all unrelated objects
+        System.gc();
+    }
 
     @Setup(Level.Iteration)
     public void generateGarbage() {


### PR DESCRIPTION
Clean backport. tested locally by running `sudo make test TEST="micro:vm.gc.systemgc"`
```

Benchmark                       Mode  Cnt    Score   Error  Units
AllDead.gc                        ss  125   12.133 ± 1.641  ms/op
AllLive.gc                        ss  125   44.718 ± 1.723  ms/op
DifferentObjectSizesArray.gc      ss  125   78.024 ± 5.487  ms/op
DifferentObjectSizesHashMap.gc    ss  125   90.232 ± 3.675  ms/op
DifferentObjectSizesTreeMap.gc    ss  125  105.918 ± 3.267  ms/op
HalfDeadFirstPart.gc              ss  125   27.406 ± 0.601  ms/op
HalfDeadInterleaved.gc            ss  125   88.963 ± 0.827  ms/op
HalfDeadInterleavedChunks.gc      ss  125   74.533 ± 3.662  ms/op
HalfDeadSecondPart.gc             ss  125   27.213 ± 0.452  ms/op
HalfHashedHalfDead.gc             ss  125   95.042 ± 1.031  ms/op
NoObjects.gc                      ss  125    9.586 ± 0.327  ms/op
OneBigObject.gc                   ss  125   74.786 ± 2.621  ms/op
Finished running test 'micro:vm.gc.systemgc'
Test report is stored in /Users/kavyaks/jdk25u-cpu/build/macosx-x64/test-results/micro_vm_gc_systemgc
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  SKIP
   micro:vm.gc.systemgc                                  1     1     0     0     0
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8361520](https://bugs.openjdk.org/browse/JDK-8361520) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361520](https://bugs.openjdk.org/browse/JDK-8361520): Stabilize SystemGC benchmarks (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/237/head:pull/237` \
`$ git checkout pull/237`

Update a local copy of the PR: \
`$ git checkout pull/237` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 237`

View PR using the GUI difftool: \
`$ git pr show -t 237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/237.diff">https://git.openjdk.org/jdk25u/pull/237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/237#issuecomment-3326997770)
</details>
