### PR TITLE
8368366: RISC-V: AlignVector is mistakenly set to AvoidUnalignedAccesses

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -477,10 +477,6 @@ void VM_Version::c2_initialize() {
     warning("AES/CTR intrinsics are not available on this CPU");
     FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
   }
-
-  if (FLAG_IS_DEFAULT(AlignVector)) {
-    FLAG_SET_DEFAULT(AlignVector, AvoidUnalignedAccesses);
-  }
 }
 
 #endif // COMPILER2


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2313f8e4](https://github.com/openjdk/jdk/commit/2313f8e4ebe5b6d7542fa8a33fd08673cc0caf10) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Fei Yang on 24 Sep 2025 and was reviewed by Feilong Jiang, Robbin Ehn and Hamlin Li.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368366](https://bugs.openjdk.org/browse/JDK-8368366) needs maintainer approval

### Issue
 * [JDK-8368366](https://bugs.openjdk.org/browse/JDK-8368366): RISC-V: AlignVector is mistakenly set to AvoidUnalignedAccesses (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/238/head:pull/238` \
`$ git checkout pull/238`

Update a local copy of the PR: \
`$ git checkout pull/238` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 238`

View PR using the GUI difftool: \
`$ git pr show -t 238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/238.diff">https://git.openjdk.org/jdk25u/pull/238.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/238#issuecomment-3328077137)
</details>
