### PR TITLE
8368367: Test jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java fails  jdk.GCHeapMemoryUsage "expected 0 > 0"

### DIFF
--- a/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java
+++ b/test/jdk/jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class TestGCHeapMemoryUsageEvent {
             List<RecordedEvent> events = Events.fromRecording(recording);
             System.out.println(events);
             assertFalse(events.isEmpty());
-            RecordedEvent event = events.getFirst();
+            RecordedEvent event = events.getLast();
             Events.assertField(event, "used").above(0L);
             Events.assertField(event, "committed").above(0L);
             Events.assertField(event, "max").above(0L);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ed31023f](https://github.com/openjdk/jdk/commit/ed31023fc5a96a6f9a16c8a5c0fc86e794ce4aa7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Schatzl on 24 Sep 2025 and was reviewed by Ivan Walulya, Albert Mingkun Yang and SendaoYan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8368367](https://bugs.openjdk.org/browse/JDK-8368367) needs maintainer approval

### Issue
 * [JDK-8368367](https://bugs.openjdk.org/browse/JDK-8368367): Test jdk/jfr/event/gc/detailed/TestGCHeapMemoryUsageEvent.java fails  jdk.GCHeapMemoryUsage "expected 0 &gt; 0" (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/239/head:pull/239` \
`$ git checkout pull/239`

Update a local copy of the PR: \
`$ git checkout pull/239` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 239`

View PR using the GUI difftool: \
`$ git pr show -t 239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/239.diff">https://git.openjdk.org/jdk25u/pull/239.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/239#issuecomment-3328913460)
</details>
