### PR TITLE
8333783: java/nio/channels/FileChannel/directio/DirectIOTest.java is unstable with AV software

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
+++ b/test/jdk/java/nio/channels/FileChannel/directio/DirectIOTest.java
@@ -27,11 +27,13 @@
  * @summary Test for ExtendedOpenOption.DIRECT flag
  * @requires (os.family == "linux" | os.family == "aix")
  * @library /test/lib
+ * @modules java.base/sun.nio.ch:+open java.base/java.io:+open
  * @build jdk.test.lib.Platform
  * @run main/native DirectIOTest
  */
 
 import java.io.*;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.*;
@@ -47,10 +49,25 @@ import com.sun.nio.file.ExtendedOpenOption;
 public class DirectIOTest {
 
     private static final int BASE_SIZE = 4096;
+    private static final int TRIES = 3;
 
-    private static int testWrite(Path p, long blockSize) throws Exception {
-        try (FileChannel fc = FileChannel.open(p, StandardOpenOption.WRITE,
-             ExtendedOpenOption.DIRECT)) {
+    public static int getFD(FileChannel channel) throws Exception {
+        Field fFdFd = channel.getClass().getDeclaredField("fd");
+        fFdFd.setAccessible(true);
+        FileDescriptor fd = (FileDescriptor) fFdFd.get(channel);
+
+        Field fFd = FileDescriptor.class.getDeclaredField("fd");
+        fFd.setAccessible(true);
+        return fFd.getInt(fd);
+    }
+
+    private static void testWrite(Path p, long blockSize) throws Exception {
+        try (FileChannel fc = FileChannel.open(p,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE,
+                ExtendedOpenOption.DIRECT)) {
+            int fd = getFD(fc);
+
             int bs = (int)blockSize;
             int size = Math.max(BASE_SIZE, bs);
             int alignment = bs;
@@ -60,22 +77,55 @@ public class DirectIOTest {
             for (int j = 0; j < size; j++) {
                 src.put((byte)0);
             }
-            src.flip();
-            fc.write(src);
-            return size;
+
+            // If there is AV or other FS tracing software, it may cache the file
+            // contents on first access, even though we have asked for DIRECT here.
+            // Do several attempts to make test more resilient.
+
+            for (int t = 0; t < TRIES; t++) {
+                flushFileCache(size, fd);
+                src.flip();
+                fc.position(0);
+                fc.write(src);
+                if (!isFileInCache(size, fd)) {
+                    return;
+                }
+            }
+
+            throw new RuntimeException("DirectIO is not working properly with " +
+                                       "write. File still exists in cache!");
         }
     }
 
-    private static int testRead(Path p, long blockSize) throws Exception {
-        try (FileChannel fc = FileChannel.open(p, ExtendedOpenOption.DIRECT)) {
+    private static void testRead(Path p, long blockSize) throws Exception {
+        try (FileChannel fc = FileChannel.open(p,
+                StandardOpenOption.READ,
+                ExtendedOpenOption.DIRECT)) {
+            int fd = getFD(fc);
+
             int bs = (int)blockSize;
             int size = Math.max(BASE_SIZE, bs);
             int alignment = bs;
             ByteBuffer dest = ByteBuffer.allocateDirect(size + alignment - 1)
                                         .alignedSlice(alignment);
             assert dest.capacity() != 0;
-            fc.read(dest);
-            return size;
+
+            // If there is AV or other FS tracing software, it may cache the file
+            // contents on first access, even though we have asked for DIRECT here.
+            // Do several attempts to make test more resilient.
+
+            for (int t = 0; t < TRIES; t++) {
+                flushFileCache(size, fd);
+                dest.clear();
+                fc.position(0);
+                fc.read(dest);
+                if (!isFileInCache(size, fd)) {
+                    return;
+                }
+            }
+
+            throw new RuntimeException("DirectIO is not working properly with " +
+                                       "read. File still exists in cache!");
         }
     }
 
@@ -84,12 +134,8 @@ public class DirectIOTest {
             Paths.get(System.getProperty("test.dir", ".")), "test", null);
     }
 
-    private static boolean isFileInCache(int size, Path p) {
-        String path = p.toString();
-        return isFileInCache0(size, path);
-    }
-
-    private static native boolean isFileInCache0(int size, String path);
+    private static native boolean flushFileCache(int size, int fd);
+    private static native boolean isFileInCache(int size, int fd);
 
     public static void main(String[] args) throws Exception {
         Path p = createTempFile();
@@ -98,16 +144,8 @@ public class DirectIOTest {
         System.loadLibrary("DirectIO");
 
         try {
-            int size = testWrite(p, blockSize);
-            if (isFileInCache(size, p)) {
-                throw new RuntimeException("DirectIO is not working properly with "
-                    + "write. File still exists in cache!");
-            }
-            size = testRead(p, blockSize);
-            if (isFileInCache(size, p)) {
-                throw new RuntimeException("DirectIO is not working properly with "
-                    + "read. File still exists in cache!");
-            }
+            testWrite(p, blockSize);
+            testRead(p, blockSize);
         } finally {
             Files.delete(p);
         }


### PR DESCRIPTION
Stabilizes the test.

Additional testing:
 - [x] Linux x86_64 server fastdebug, affected test, 100x repetitions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8333783](https://bugs.openjdk.org/browse/JDK-8333783) needs maintainer approval

### Issue
 * [JDK-8333783](https://bugs.openjdk.org/browse/JDK-8333783): java/nio/channels/FileChannel/directio/DirectIOTest.java is unstable with AV software (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/246/head:pull/246` \
`$ git checkout pull/246`

Update a local copy of the PR: \
`$ git checkout pull/246` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 246`

View PR using the GUI difftool: \
`$ git pr show -t 246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/246.diff">https://git.openjdk.org/jdk25u/pull/246.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/246#issuecomment-3335292115)
</details>
