### PR TITLE
8358340: Support CDS heap archive with Generational Shenandoah

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -680,7 +680,7 @@ public:
 
 // ---------- CDS archive support
 
-  bool can_load_archived_objects() const override { return !ShenandoahCardBarrier; }
+  bool can_load_archived_objects() const override { return true; }
   HeapWord* allocate_loaded_archive_space(size_t size) override;
   void complete_loaded_archive_space(MemRegion archive_space) override;
 


### PR DESCRIPTION
Enables AOT/CDS caches with Generational Shenandoah.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds` with Generational Shenandoah
 - [x] Linux x86_64 server fastdebug, `all` with Shenandoah
 - [x] Linux x86_64 server fastdebug, `all` with Generational Shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8358340](https://bugs.openjdk.org/browse/JDK-8358340) needs maintainer approval

### Issue
 * [JDK-8358340](https://bugs.openjdk.org/browse/JDK-8358340): Support CDS heap archive with Generational Shenandoah (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/248/head:pull/248` \
`$ git checkout pull/248`

Update a local copy of the PR: \
`$ git checkout pull/248` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 248`

View PR using the GUI difftool: \
`$ git pr show -t 248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/248.diff">https://git.openjdk.org/jdk25u/pull/248.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/248#issuecomment-3345399494)
</details>
