### PR TITLE
8368732: RISC-V: Detect support for misaligned vector access via hwprobe

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -147,7 +147,7 @@ void VM_Version::common_initialize() {
 
   if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
     FLAG_SET_DEFAULT(AvoidUnalignedAccesses,
-      unaligned_access.value() != MISALIGNED_FAST);
+      unaligned_scalar.value() != MISALIGNED_SCALAR_FAST);
   }
 
   if (!AvoidUnalignedAccesses) {
@@ -162,7 +162,12 @@ void VM_Version::common_initialize() {
   // This machine has fast unaligned memory accesses
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses,
-      unaligned_access.value() == MISALIGNED_FAST);
+      (unaligned_scalar.value() == MISALIGNED_SCALAR_FAST));
+  }
+
+  if (FLAG_IS_DEFAULT(AlignVector)) {
+    FLAG_SET_DEFAULT(AlignVector,
+      unaligned_vector.value() != MISALIGNED_VECTOR_FAST);
   }
 
 #ifdef __riscv_ztso

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -153,7 +153,8 @@ class VM_Version : public Abstract_VM_Version {
   // mvendorid Manufactory JEDEC id encoded, ISA vol 2 3.1.2..
   // marchid   Id for microarch. Mvendorid plus marchid uniquely identify the microarch.
   // mimpid    A unique encoding of the version of the processor implementation.
-  // unaligned_access Unaligned memory accesses (unknown, unspported, emulated, slow, firmware, fast)
+  // unaligned_scalar Performance of misaligned scalar accesses (unknown, emulated, slow, fast, unsupported)
+  // unaligned_vector Performance of misaligned vector accesses (unknown, unspported, slow, fast)
   // satp mode SATP bits (number of virtual addr bits) mbare, sv39, sv48, sv57, sv64
 
  public:
@@ -199,8 +200,9 @@ class VM_Version : public Abstract_VM_Version {
   decl(mvendorid        , "VendorId"       , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
   decl(marchid          , "ArchId"         , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
   decl(mimpid           , "ImpId"          , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
-  decl(unaligned_access , "Unaligned"      , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
   decl(satp_mode        , "SATP"           , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
+  decl(unaligned_scalar , "UnalignedScalar", RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
+  decl(unaligned_vector , "UnalignedVector", RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
   decl(zicboz_block_size, "ZicbozBlockSize", RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)                  \
 
   #define DECLARE_RV_FEATURE(NAME, PRETTY, BIT, FSTRING, FLAGF)        \
@@ -276,12 +278,19 @@ class VM_Version : public Abstract_VM_Version {
   static VM_MODE parse_satp_mode(const char* vm_mode);
 
   // Values from riscv_hwprobe()
-  enum UNALIGNED_ACCESS : int {
-    MISALIGNED_UNKNOWN     = 0,
-    MISALIGNED_EMULATED    = 1,
-    MISALIGNED_SLOW        = 2,
-    MISALIGNED_FAST        = 3,
-    MISALIGNED_UNSUPPORTED = 4
+  enum UNALIGNED_SCALAR_ACCESS : int {
+    MISALIGNED_SCALAR_UNKNOWN     = 0,
+    MISALIGNED_SCALAR_EMULATED    = 1,
+    MISALIGNED_SCALAR_SLOW        = 2,
+    MISALIGNED_SCALAR_FAST        = 3,
+    MISALIGNED_SCALAR_UNSUPPORTED = 4
+  };
+
+  enum UNALIGNED_VECTOR_ACCESS : int {
+    MISALIGNED_VECTOR_UNKNOWN     = 0,
+    MISALIGNED_VECTOR_SLOW        = 2,
+    MISALIGNED_VECTOR_FAST        = 3,
+    MISALIGNED_VECTOR_UNSUPPORTED = 4
   };
 
   // Null terminated list

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -303,7 +303,7 @@ void VM_Version::rivos_features() {
 
   ext_Zvfh.enable_feature();
 
-  unaligned_access.enable_feature(MISALIGNED_FAST);
+  unaligned_scalar.enable_feature(MISALIGNED_SCALAR_FAST);
   satp_mode.enable_feature(VM_SV48);
 
   // Features dependent on march/mimpid.


### PR DESCRIPTION
Hi,
Please help review this backport to jdk25u, thanks!

Backport of [JDK-8368732](https://bugs.openjdk.org/browse/JDK-8368732).

The original patch cannot be directly applied because of jdk25u do not have [JDK-8367253](https://bugs.openjdk.org/browse/JDK-8367253) or [JDK-8367103](https://bugs.openjdk.org/browse/JDK-8367103).

Manually checked the result on platforms w/wo fast misaligned vector accesses by running:
```
$ java -XX:+PrintFlagsFinal -version | grep AlignVector
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8368732](https://bugs.openjdk.org/browse/JDK-8368732) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8368732](https://bugs.openjdk.org/browse/JDK-8368732): RISC-V: Detect support for misaligned vector access via hwprobe (**Enhancement** - P4 - Approved)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/252/head:pull/252` \
`$ git checkout pull/252`

Update a local copy of the PR: \
`$ git checkout pull/252` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 252`

View PR using the GUI difftool: \
`$ git pr show -t 252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/252.diff">https://git.openjdk.org/jdk25u/pull/252.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/252#issuecomment-3350361178)
</details>
