### PR TITLE
Backport ad0fd13f2007c93d8a109626a627823f30e4c8d7

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -98,6 +98,7 @@ gc/shenandoah/TestEvilSyncBug.java#generational 8345501 generic-all
 
 # :hotspot_runtime
 
+runtime/cds/DeterministicDump.java 8363986 macosx-x64,macosx-aarch64
 runtime/jni/terminatedThread/TestTerminatedThread.java 8317789 aix-ppc64
 runtime/Monitor/SyncOnValueBasedClassTest.java 8340995 linux-s390x
 runtime/os/TestTracePageSizes.java#no-options 8267460 linux-aarch64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8364454](https://bugs.openjdk.org/browse/JDK-8364454), commit [ad0fd13f](https://github.com/openjdk/jdk/commit/ad0fd13f2007c93d8a109626a627823f30e4c8d7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Ioi Lam on 12 Aug 2025 and was reviewed by Calvin Cheung.

It excludes a test for which a fix is in the makings in head.

Thanks!