### PR TITLE
8362282: runtime/logging/StressAsyncUL.java failed with exitValue = 134

### DIFF
--- a/src/hotspot/share/logging/logAsyncWriter.cpp
+++ b/src/hotspot/share/logging/logAsyncWriter.cpp
@@ -318,13 +318,13 @@ void AsyncLogWriter::initialize() {
 
   AsyncLogWriter* self = new AsyncLogWriter();
   if (self->_initialized) {
-    Atomic::release_store_fence(&AsyncLogWriter::_instance, self);
-    // All readers of _instance after the fence see non-null.
     // We use LogOutputList's RCU counters to ensure all synchronous logsites have completed.
-    // After that, we start AsyncLog Thread and it exclusively takes over all logging I/O.
+    // After that, we publish the initalized _instance to readers.
+    // Then we start the AsyncLog Thread and it exclusively takes over all logging I/O.
     for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       ts->wait_until_no_readers();
     }
+    Atomic::release_store_fence(&AsyncLogWriter::_instance, self);
     os::start_thread(self);
     log_debug(logging, thread)("Async logging thread started.");
   } else {


### PR DESCRIPTION
Improves `-Xlog:async` reliability.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all`
 - [x] Linux x86_64 server fastdebug, `all` with `-Xlog:async`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8362282](https://bugs.openjdk.org/browse/JDK-8362282) needs maintainer approval

### Issue
 * [JDK-8362282](https://bugs.openjdk.org/browse/JDK-8362282): runtime/logging/StressAsyncUL.java failed with exitValue = 134 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/254/head:pull/254` \
`$ git checkout pull/254`

Update a local copy of the PR: \
`$ git checkout pull/254` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 254`

View PR using the GUI difftool: \
`$ git pr show -t 254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/254.diff">https://git.openjdk.org/jdk25u/pull/254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/254#issuecomment-3357328889)
</details>
