### PR TITLE
8345810: Custom launchers must be linked with pthread to avoid dynamic linker issues

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -68,7 +68,7 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGEAPPLAUNCHER, \
         -rpath @executable_path/../PlugIns/, \
     LIBS_macosx := -framework Cocoa, \
     LIBS_windows := msi.lib ole32.lib shell32.lib shlwapi.lib user32.lib, \
-    LIBS_linux := $(LIBDL), \
+    LIBS_linux := $(LIBDL) $(LIBPTHREAD), \
     MANIFEST := $(JAVA_MANIFEST), \
     MANIFEST_VERSION := $(VERSION_NUMBER_FOUR_POSITIONS) \
 ))
@@ -97,7 +97,7 @@ ifeq ($(call isTargetOs, linux), true)
       DISABLED_WARNINGS_clang_JvmLauncherLib.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_tstrings.cpp := format-nonliteral, \
       LD_SET_ORIGIN := false, \
-      LIBS_linux := $(LIBDL), \
+      LIBS_linux := $(LIBDL) $(LIBPTHREAD), \
   ))
 
   TARGETS += $(BUILD_LIBJPACKAGEAPPLAUNCHERAUX)

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -138,6 +138,7 @@ ifneq ($(filter build-test-jdk-jtreg-native, $(MAKECMDGOALS)), )
       OUTPUT_DIR := $(BUILD_JDK_JTREG_OUTPUT_DIR), \
       EXCLUDE := $(BUILD_JDK_JTREG_EXCLUDE), \
       EXTRA_FILES := $(BUILD_JDK_JTREG_EXTRA_FILES), \
+      LIBS := $(LIBPTHREAD), \
   ))
 endif
 


### PR DESCRIPTION
Improves jpackage and test reliability, especially with older glibc-s that have `dlerror` issues under concurrent access.

Additional testing:
 - [x] Linux x86_64 server fastdebug, observing the failure with GCC 7.3.1
 - [x] Linux x86_64 server fastdebug, `sun/management/jmxremote`, 20x, no failures
 - [x] Linux x86_64 server fastdebug, `tools/jpackage`, 5x, no failures
 - [x] Linux x86_64 server fastdebug, `jdk_all`, no failures

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8345810](https://bugs.openjdk.org/browse/JDK-8345810) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345810](https://bugs.openjdk.org/browse/JDK-8345810): Custom launchers must be linked with pthread to avoid dynamic linker issues (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/257/head:pull/257` \
`$ git checkout pull/257`

Update a local copy of the PR: \
`$ git checkout pull/257` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 257`

View PR using the GUI difftool: \
`$ git pr show -t 257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/257.diff">https://git.openjdk.org/jdk25u/pull/257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/257#issuecomment-3358226740)
</details>
