### PR TITLE
Backport 38a261415dc29aae01c9b878d94cb302c60a3983

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.cpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.cpp
@@ -137,7 +137,7 @@ void MethodHandles::verify_method(MacroAssembler* _masm, Register method, Regist
       case vmIntrinsicID::_invokeBasic:
         // Require compiled LambdaForm class to be fully initialized.
         __ cmpb(Address(method_holder, InstanceKlass::init_state_offset()), InstanceKlass::fully_initialized);
-        __ jccb(Assembler::equal, L_ok);
+        __ jcc(Assembler::equal, L_ok);
         break;
 
       case vmIntrinsicID::_linkToStatic:
@@ -154,7 +154,7 @@ void MethodHandles::verify_method(MacroAssembler* _masm, Register method, Regist
         // init_state check failed, but it may be an abstract interface method
         __ load_unsigned_short(temp, Address(method, Method::access_flags_offset()));
         __ testl(temp, JVM_ACC_ABSTRACT);
-        __ jccb(Assembler::notZero, L_ok);
+        __ jcc(Assembler::notZero, L_ok);
         break;
 
       default:


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [38a26141](https://github.com/openjdk/jdk/commit/38a261415dc29aae01c9b878d94cb302c60a3983) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Srinivas Vamsi Parasa on 13 Aug 2025 and was reviewed by Aleksey Shipilev, Jatin Bhateja and Andrew Haley.

Thanks!