### PR TITLE
8365425: [macos26] javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java fails on macOS 26

### DIFF
--- a/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
+++ b/test/jdk/javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Point;
@@ -28,6 +29,7 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
@@ -51,6 +53,7 @@ public class JInternalFrameDraggingTest {
     private static JInternalFrame internalFrame;
     private static int FRAME_SIZE = 500;
     private static Color BACKGROUND_COLOR = Color.ORANGE;
+    private static final int tolerance = 10;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -69,14 +72,24 @@ public class JInternalFrameDraggingTest {
             BufferedImage img = robot.createScreenCapture(rect);
 
             int testRGB = BACKGROUND_COLOR.getRGB();
+            Color testColor = new Color(testRGB);
             for (int i = 1; i < size; i++) {
                 int rgbCW = img.getRGB(i, size / 2);
                 int rgbCH = img.getRGB(size / 2, i);
-                if (rgbCW != testRGB || rgbCH != testRGB) {
+                Color rgbCWColor = new Color(rgbCW);
+                Color rgbCHColor = new Color(rgbCH);
+
+                if (Math.abs(rgbCWColor.getRed() - testColor.getRed()) > tolerance
+                    || Math.abs(rgbCWColor.getGreen() - testColor.getGreen()) > tolerance
+                    || Math.abs(rgbCWColor.getBlue() - testColor.getBlue()) > tolerance
+                    || Math.abs(rgbCHColor.getRed() - testColor.getRed()) > tolerance
+                    || Math.abs(rgbCHColor.getGreen() - testColor.getGreen()) > tolerance
+                    || Math.abs(rgbCHColor.getBlue() - testColor.getBlue()) > tolerance) {
                     System.out.println("i " + i + " rgbCW " +
                                        Integer.toHexString(rgbCW) +
                                        " testRGB " + Integer.toHexString(testRGB) +
                                        " rgbCH " + Integer.toHexString(rgbCH));
+                    ImageIO.write(img, "png", new File("JInternalFrameDraggingTest.png"));
                     throw new RuntimeException("Background color is wrong!");
                 }
             }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit bdf9834 from the openjdk/jdk repository.

The commit being backported was authored by Prasanta Sadhukhan and was reviewed by Alexander Zuev and Damon Nguyen.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8365425](https://bugs.openjdk.org/browse/JDK-8365425) needs maintainer approval

### Issue
 * [JDK-8365425](https://bugs.openjdk.org/browse/JDK-8365425): [macos26] javax/swing/JInternalFrame/8160248/JInternalFrameDraggingTest.java fails on macOS 26 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/264/head:pull/264` \
`$ git checkout pull/264`

Update a local copy of the PR: \
`$ git checkout pull/264` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 264`

View PR using the GUI difftool: \
`$ git pr show -t 264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/264.diff">https://git.openjdk.org/jdk25u/pull/264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/264#issuecomment-3361726673)
</details>
