### PR TITLE
8366750: Remove test 'java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java' from problemlist

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -261,7 +261,7 @@ java/awt/FullScreen/DisplayChangeVITest/DisplayChangeVITest.java 8169469,8273617
 java/awt/FullScreen/UninitializedDisplayModeChangeTest/UninitializedDisplayModeChangeTest.java 8273617 macosx-all
 java/awt/print/PrinterJob/PSQuestionMark.java 7003378 generic-all
 java/awt/print/PrinterJob/GlyphPositions.java 7003378 generic-all
-java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 6849371 macosx-all,linux-all
+java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java 8366852 generic-all
 java/awt/Component/GetScreenLocTest/GetScreenLocTest.java 4753654 generic-all
 java/awt/Component/SetEnabledPerformance/SetEnabledPerformance.java 8165863 macosx-all
 java/awt/Clipboard/PasteNullToTextComponentsTest.java 8234140 macosx-all,windows-all


### PR DESCRIPTION
- PR Changes
The test is problem listed with incorrect bug JDK-6849371. JDK-6849371 is for a different test and it is closed.
A new bug has been raised for ChoiceMouseWheelTest.java test failure.

- Conflicts
No conflicts. Clean backport.

- Are higher backports completed(25u,21u,17u,11u,8u etc) ?
Applicable to 25u via this MR and the others are being worked upon.

- Does it contain multiple changesets ?
No

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8366750](https://bugs.openjdk.org/browse/JDK-8366750) needs maintainer approval

### Issue
 * [JDK-8366750](https://bugs.openjdk.org/browse/JDK-8366750): Remove test 'java/awt/Choice/ChoiceMouseWheelTest/ChoiceMouseWheelTest.java' from problemlist (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/268/head:pull/268` \
`$ git checkout pull/268`

Update a local copy of the PR: \
`$ git checkout pull/268` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 268`

View PR using the GUI difftool: \
`$ git pr show -t 268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/268.diff">https://git.openjdk.org/jdk25u/pull/268.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/268#issuecomment-3370670057)
</details>
