### PR TITLE
8367313: CTW: Execute in AWT headless mode

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -292,6 +292,8 @@ public class CtwRunner {
                 "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
                 "--add-exports", "java.base/jdk.internal.reflect=ALL-UNNAMED",
                 "--add-exports", "java.base/jdk.internal.access=ALL-UNNAMED",
+                // Graphics clinits may run, force headless mode
+                "-Djava.awt.headless=true",
                 // enable diagnostic logging
                 "-XX:+LogCompilation",
                 // use phase specific log, hs_err and ciReplay files


### PR DESCRIPTION
Improves CTW reliability.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `applications/ctw/modules`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] [JDK-8367313](https://bugs.openjdk.org/browse/JDK-8367313) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8367313](https://bugs.openjdk.org/browse/JDK-8367313): CTW: Execute in AWT headless mode (**Enhancement** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/271/head:pull/271` \
`$ git checkout pull/271`

Update a local copy of the PR: \
`$ git checkout pull/271` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 271`

View PR using the GUI difftool: \
`$ git pr show -t 271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/271.diff">https://git.openjdk.org/jdk25u/pull/271.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/271#issuecomment-3372795979)
</details>
