### PR TITLE
Backport 016694bf74f6920f850330e353df9fd03458cca1

### DIFF
--- a/test/jdk/java/io/File/MaxPathLength.java
+++ b/test/jdk/java/io/File/MaxPathLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,14 +60,7 @@ public class MaxPathLength {
 
         // test long paths on windows
         // And these long pathes cannot be handled on Solaris and Mac platforms
-        if (isWindows) {
-            String name = fileName;
-            while (name.length() < MAX_LENGTH) {
-                testLongPath (20, name, false);
-                testLongPath (20, name, true);
-                name = getNextName(name);
-            }
-        }
+        testLongPathOnWindows();
     }
 
     private static String getNextName(String fName) {
@@ -196,6 +189,17 @@ public class MaxPathLength {
                     System.err.println("Dir, " + p + ", is not empty");
                     break;
                 }
+            }
+        }
+    }
+
+    private static void testLongPathOnWindows () throws Exception {
+        if (isWindows) {
+            String name = fileName;
+            while (name.length() < MAX_LENGTH) {
+                testLongPath (20, name, false);
+                testLongPath (20, name, true);
+                name = getNextName(name);
             }
         }
     }


### PR DESCRIPTION
Two issues in this backport:
- (prerequisite) https://bugs.openjdk.org/browse/JDK-8360411
- (follow up) https://bugs.openjdk.org/browse/JDK-8363720

Both patches are in oracle 21 & 17. For some reason oracle hasn't backported those to 25. Backporting them to 25. Tests are running.