### PR TITLE
Backport 7698c373a684235812c9dc11edd751059f9e8e81

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -33,12 +33,12 @@
     </event>
 
     <event name="jdk.SymbolTableStatistics">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="period">10 s</setting>
     </event>
 
     <event name="jdk.StringTableStatistics">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="period">10 s</setting>
     </event>
 


### PR DESCRIPTION
This pull request contains a backport of commit [7698c373](https://github.com/openjdk/jdk/commit/7698c373a684235812c9dc11edd751059f9e8e81) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Erik Gahlin on 14 Aug 2025 and was reviewed by Markus Grönlund.

Thanks!