### PR TITLE
Backport a382996bb496d50b4eb5a6be9f61e5c2f8aaae2d

### DIFF
--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -762,7 +762,7 @@
     </event>
 
     <event name="jdk.ModuleExport">
-      <setting name="enabled">true</setting>
+      <setting name="enabled">false</setting>
       <setting name="period">endChunk</setting>
     </event>
 


### PR DESCRIPTION
This pull request contains a backport of commit [a382996b](https://github.com/openjdk/jdk/commit/a382996bb496d50b4eb5a6be9f61e5c2f8aaae2d) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Erik Gahlin on 12 Aug 2025 and was reviewed by Markus Grönlund.

Thanks!