### PR TITLE
8362581: Timeouts in java/nio/channels/SocketChannel/OpenLeak.java on UNIX

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/Exceptions.java
+++ b/src/java.base/share/classes/jdk/internal/util/Exceptions.java
@@ -274,11 +274,8 @@ public final class Exceptions {
      */
     public static IOException ioException(IOException e, SocketAddress addr) {
         setup();
-        if (addr == null) {
+        if (!enhancedSocketExceptionText || addr == null) {
             return e;
-        }
-        if (!enhancedSocketExceptionText) {
-            return create(e, e.getMessage());
         }
         if (addr instanceof UnixDomainSocketAddress) {
             return ofUnixDomain(e, (UnixDomainSocketAddress)addr);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8362581](https://bugs.openjdk.org/browse/JDK-8362581) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8362581](https://bugs.openjdk.org/browse/JDK-8362581): Timeouts in java/nio/channels/SocketChannel/OpenLeak.java on UNIX (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/278.diff">https://git.openjdk.org/jdk25u/pull/278.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/278#issuecomment-3377221123)
</details>
