### PR TITLE
8381935: Improve numChunks range in the PPC64 CallAranger

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/ppc64/CallArranger.java
@@ -245,7 +245,12 @@ public abstract class CallArranger {
         // Regular struct, no HFA.
         VMStorage[] structAlloc(MemoryLayout layout) {
             // Allocate enough gp slots (regs and stack) such that the struct fits in them.
-            int numChunks = (int) Utils.alignUp(layout.byteSize(), MAX_COPY_SIZE) / MAX_COPY_SIZE;
+            final int numChunks;
+            try {
+                numChunks = Math.toIntExact(Utils.alignUp(layout.byteSize(), MAX_COPY_SIZE) / MAX_COPY_SIZE);
+            } catch (ArithmeticException ae) {
+                throw new IllegalArgumentException("Layout too large: " + layout, ae);
+            }
             VMStorage[] result = new VMStorage[numChunks];
             for (int i = 0; i < numChunks; i++) {
                 result[i] = nextStorage(StorageType.INTEGER, false);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [61849f47](https://github.com/openjdk/jdk/commit/61849f47add0d96d4723858f10fe67de411c4166) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 20 Apr 2026 and was reviewed by Martin Doerr.

Thanks!

- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8381935](https://bugs.openjdk.org/browse/JDK-8381935): Improve numChunks range in the PPC64 CallAranger (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/412/head:pull/412` \
`$ git checkout pull/412`

Update a local copy of the PR: \
`$ git checkout pull/412` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 412`

View PR using the GUI difftool: \
`$ git pr show -t 412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/412.diff">https://git.openjdk.org/jdk25u/pull/412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/412#issuecomment-4294265811)
</details>
