### PR TITLE
8369128: ProblemList jdk/jfr/event/profiling/TestCPUTimeSampleQueueAutoSizes.java in Xcomp configs

### DIFF
--- a/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryDataRunner.java
+++ b/test/hotspot/jtreg/gc/g1/TestShrinkAuxiliaryDataRunner.java
@@ -29,6 +29,7 @@ package gc.g1;
  * @bug 8038423 8061715
  * @summary Checks that decommitment occurs for JVM with different ObjectAlignmentInBytes values
  * @requires vm.gc.G1
+ * @requires !vm.opt.final.UseLargePages
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/vmTestbase/gc/vector/CircularListLow/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/vector/CircularListLow/TestDescription.java
@@ -31,5 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @requires vm.gc != "Serial"
  * @run main/othervm gc.vector.SimpleGC.SimpleGC -ms low -gp circularList(low)
  */

--- a/test/hotspot/jtreg/vmTestbase/gc/vector/LinearListLow/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/vector/LinearListLow/TestDescription.java
@@ -31,5 +31,6 @@
  *
  * @library /vmTestbase
  *          /test/lib
+ * @requires vm.gc != "Serial"
  * @run main/othervm gc.vector.SimpleGC.SimpleGC -ms low -gp linearList(low)
  */


### PR DESCRIPTION
Same as https://github.com/openjdk/jdk25u-dev/pull/596, but for jdk25u:
Backport of https://github.com/openjdk/jdk/commit/837f634bf29fd877dd62a2e0f7d7a1bd383372d3 which consists of 3 test fixes.
I've reverted the change in test/jdk/ProblemList-Xcomp.txt because [JDK-8367302](https://bugs.openjdk.org/browse/JDK-8367302) is already backported to 25.0.3 which would remove it from problem list if it was backported in consistent order.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8369128](https://bugs.openjdk.org/browse/JDK-8369128) needs maintainer approval
- \[x\] [JDK-8369133](https://bugs.openjdk.org/browse/JDK-8369133) needs maintainer approval
- \[x\] [JDK-8369132](https://bugs.openjdk.org/browse/JDK-8369132) needs maintainer approval

### Issues
 * [JDK-8369128](https://bugs.openjdk.org/browse/JDK-8369128): ProblemList jdk/jfr/event/profiling/TestCPUTimeSampleQueueAutoSizes.java in Xcomp configs (**Sub-task** - P4 - Approved)
 * [JDK-8369132](https://bugs.openjdk.org/browse/JDK-8369132): Disable vmTestbase/gc/vector/CircularListLow and LinearListLow with SerialGC (**Sub-task** - P3 - Approved)
 * [JDK-8369133](https://bugs.openjdk.org/browse/JDK-8369133): Disable gc/g1/TestShrinkAuxiliaryDataRunner.java with UseLargePages option (**Sub-task** - P4 - Approved)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/413/head:pull/413` \
`$ git checkout pull/413`

Update a local copy of the PR: \
`$ git checkout pull/413` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 413`

View PR using the GUI difftool: \
`$ git pr show -t 413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/413.diff">https://git.openjdk.org/jdk25u/pull/413.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/413#issuecomment-4633409829)
</details>
