### PR TITLE
8386551: Windows build broken because of MSys2/Make update

### DIFF
--- a/make/autoconf/basic_tools.m4
+++ b/make/autoconf/basic_tools.m4
@@ -148,7 +148,7 @@ AC_DEFUN([BASIC_CHECK_MAKE_VERSION],
           if test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.cygwin"; then
             MAKE_EXPECTED_ENV='cygwin'
           elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.msys2"; then
-            MAKE_EXPECTED_ENV='msys'
+            MAKE_EXPECTED_ENV='cygwin|msys'
           elif test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl1" || test "x$OPENJDK_BUILD_OS_ENV" = "xwindows.wsl2"; then
             if test "x$OPENJDK_BUILD_CPU" = "xaarch64"; then
               MAKE_EXPECTED_ENV='aarch64-.*-linux-gnu'
@@ -159,7 +159,7 @@ AC_DEFUN([BASIC_CHECK_MAKE_VERSION],
             AC_MSG_ERROR([Unknown Windows environment])
           fi
           MAKE_BUILT_FOR=`$MAKE_CANDIDATE --version | $GREP -i 'built for'`
-          IS_MAKE_CORRECT_ENV=`$ECHO $MAKE_BUILT_FOR | $GREP $MAKE_EXPECTED_ENV`
+          IS_MAKE_CORRECT_ENV=`$ECHO $MAKE_BUILT_FOR | $GREP -E $MAKE_EXPECTED_ENV`
         else
           # Not relevant for non-Windows
           IS_MAKE_CORRECT_ENV=true


### PR DESCRIPTION
I think we should also have this in the rampdown repos.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8386551](https://bugs.openjdk.org/browse/JDK-8386551) needs maintainer approval

### Issue
 * [JDK-8386551](https://bugs.openjdk.org/browse/JDK-8386551): Windows build broken because of MSys2/Make update (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/416/head:pull/416` \
`$ git checkout pull/416`

Update a local copy of the PR: \
`$ git checkout pull/416` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 416`

View PR using the GUI difftool: \
`$ git pr show -t 416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/416.diff">https://git.openjdk.org/jdk25u/pull/416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/416#issuecomment-4776394804)
</details>
