### PR TITLE
8383367: jdk/jfr/event/oldobject/TestDFSWithSmallStack.java failed with -XX:+UseZGC -XX:+UseCompactObjectHeaders

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestDFSWithSmallStack.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestDFSWithSmallStack.java
@@ -36,6 +36,7 @@ import jdk.test.lib.jfr.Events;
  * @test id=dfsonly
  * @summary Tests that DFS works with a small stack
  * @library /test/lib /test/jdk
+ * @requires vm.flagless
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -Xmx2g -XX:VMThreadStackSize=512 jdk.jfr.event.oldobject.TestDFSWithSmallStack dfsonly
@@ -45,6 +46,7 @@ import jdk.test.lib.jfr.Events;
  * @test id=bfsdfs
  * @summary Tests that DFS works with a small stack
  * @library /test/lib /test/jdk
+ * @requires vm.flagless
  * @requires vm.hasJFR
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -Xmx2g -XX:VMThreadStackSize=512 jdk.jfr.event.oldobject.TestDFSWithSmallStack bfsdfs


### PR DESCRIPTION
Hi,

This pull request contains a backport of commit [d8e2a54c](https://github.com/openjdk/jdk/commit/d8e2a54cfee10f1f4f4c7e28104f5880bddce8e8) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.
The commit being backported was authored by Markus Grönlund on 28 Apr 2026 and was reviewed by Erik Gahlin.

I am backporting this to prevent the test from failing when running with an unsupported GC passed to jtreg via `-vmoptions`.

Thanks!

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[ \] [JDK-8383367](https://bugs.openjdk.org/browse/JDK-8383367) needs maintainer approval

### Issue
 * [JDK-8383367](https://bugs.openjdk.org/browse/JDK-8383367): jdk/jfr/event/oldobject/TestDFSWithSmallStack.java failed with -XX:+UseZGC -XX:+UseCompactObjectHeaders (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/418/head:pull/418` \
`$ git checkout pull/418`

Update a local copy of the PR: \
`$ git checkout pull/418` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 418`

View PR using the GUI difftool: \
`$ git pr show -t 418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/418.diff">https://git.openjdk.org/jdk25u/pull/418.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/418#issuecomment-5115919563)
</details>
