### PR TITLE
8391256: TestZoneTextPrinterParser.java assertion fails with expected: <Mountain Standard Time> but was: <Mountain Daylight Time>

### DIFF
--- a/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
+++ b/test/jdk/java/time/test/java/time/format/TestZoneTextPrinterParser.java
@@ -64,10 +64,13 @@ import org.testng.annotations.Test;
 @Test
 public class TestZoneTextPrinterParser extends AbstractTestPrinterParser {
 
-    // Explicit dstOffset attributes from CLDR v48.2 metazone data.
+    // Explicit dstOffset attributes from CLDR pre-release v49 metazone data.
     private static final Map<String, ZoneOffset> CLDR_EXPLICIT_DST_OFFSETS = Map.of(
             "Africa/Windhoek", ZoneOffset.of("+02:00"),
+            "America/Edmonton", ZoneOffset.of("-06:00"),
+            "America/Yellowknife", ZoneOffset.of("-06:00"),
             "America/Vancouver", ZoneOffset.of("-07:00"),
+            "Canada/Mountain", ZoneOffset.of("-06:00"),
             "Canada/Pacific", ZoneOffset.of("-07:00"),
             "Europe/Dublin", ZoneOffset.of("+01:00"),
             "Eire", ZoneOffset.of("+01:00"));


### PR DESCRIPTION
Replacement for https://github.com/openjdk/jdk25u-dev/pull/772.

PR for fixing the test failure introduced by #420. It's a clean backport to OpenJDK 25. Test change only.

**Testing:**
- [x] Ran `java/time/test/java/time/format/TestZoneTextPrinterParser.java` 50 times without failure.
- [x] `test/jdk/sun/util/resources`, `test/jdk/java/time/test` and `test/jdk/java/util/TimeZone`. All pass.

Thoughts?

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8391256](https://bugs.openjdk.org/browse/JDK-8391256) needs maintainer approval

### Issue
 * [JDK-8391256](https://bugs.openjdk.org/browse/JDK-8391256): TestZoneTextPrinterParser.java assertion fails with expected: &lt;Mountain Standard Time&gt; but was: &lt;Mountain Daylight Time&gt; (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk25u.git pull/421/head:pull/421` \
`$ git checkout pull/421`

Update a local copy of the PR: \
`$ git checkout pull/421` \
`$ git pull https://git.openjdk.org/jdk25u.git pull/421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 421`

View PR using the GUI difftool: \
`$ git pr show -t 421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk25u/pull/421.diff">https://git.openjdk.org/jdk25u/pull/421.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk25u/pull/421#issuecomment-5510957227)
</details>
